### PR TITLE
Subfolder support

### DIFF
--- a/storage/storage.py
+++ b/storage/storage.py
@@ -46,14 +46,19 @@ class LocalStorage(Storage):
             for chunk in in_file:
                 out_file.write(chunk)
 
-    def load_from_filename(self, file_path):
-        shutil.copy(file_path, self._parsed_storage_uri.path)
-
-    def load_from_file(self, in_file):
+    def _ensure_exists(self):
         dirname = os.path.dirname(self._parsed_storage_uri.path)
 
         if not os.path.exists(dirname):
             os.makedirs(dirname)
+
+    def load_from_filename(self, file_path):
+        self._ensure_exists()
+
+        shutil.copy(file_path, self._parsed_storage_uri.path)
+
+    def load_from_file(self, in_file):
+        self._ensure_exists()
 
         with open(self._parsed_storage_uri.path, "wb") as out_file:
             for chunk in in_file:


### PR DESCRIPTION
This adds support for creating intermediate directories if the StorageObject represents a local file and the intermediate directories don't exist, which mirrors the behavior of CloudFiles.

It does not add symmetrical support for FTP, because we don't use it, and it would be more complicated (and potentially subject to odd FTP server behaviors, as well).

@ustudio/dev Please review.
