### PR TITLE
Add get_download_url to object_storage library

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,19 +73,21 @@ Deletes the file specified by the URI to `get_storage`
 
 #### `get_temp_url(seconds=60, key=None)` ####
 
-Returns a temp URL to the file specified by the URI to `get_storage`.
-This works for swift based protocols (e.g. cloudfiles, hpcloud) as
-well as for the local file storage.
+Returns a temp URL to the object specified by the URI to `get_storage`.
+This works for **swift** based protocols (e.g. **cloudfiles, hpcloud**) as
+well as for both local file storage objects and ftp storage objects.
 
-For swift (**OpenStack**) based protocols (**Cloudfiles, Hpcloud**),
-this will return a time-limited temporary URL which can be used to GET
-the object directly from the container in the object store. By default
-the URL will only be valid for 60 seconds, but a different timeout
-can be specified by using the `seconds=` parameter.  Note, that the
-container must already have a temp url key set for the container.
+For **swift** based protocols, this will return a time-limited temporary
+URL which can be used to GET the object directly from the container in the
+object store. By default the URL will only be valid for 60 seconds, but a
+different timeout can be specified by using the `seconds=` parameter.
+Note, that the container must already have a temp url key set for the container.
+If it does not have a temp url key, an exception will be raised.
 
-For local file storage, the call will simply return the same URI
-that was passed to `get_storage`.  All params are ignored.
+For local file storage, the call will return a URL formed by joining the `temp_url_base=`
+that was included in the URI that was passed to `get_storage` with the object name. If no
+`temp_url_base=` query param was included in the storage URI, `get_temp_url` will return
+`None` instead. (*see (file)[file] below*)
 
 ### Supported Protocols ###
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ accept the following optional parameters:
 |:----------------|:------------------------------------------------------------------------|
 | `public`        | Whether or not to use the internal ServiceNet network. This saves bandwidth if you are accessing CloudFiles from within the same datacenter.  (default: true)           |
 | `api_key`       | API key to be used during authentication.                               |
-| `temp_url_key`  | Key to be used when retrieving a temp url to the storage object from the **Swift** object store (see `get_temp_url()`|
+| `temp_url_key`  | Key to be used when retrieving a temp url to the storage object from the **Swift** object store (see `get_temp_url()`)|
 
 
 #### cloudfiles ####

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ Downloads the contents of the file specified by the URI to
 
 Deletes the file specified by the URI to `get_storage`
 
-#### `get_temp_url(seconds=60, key=None)` ####
+#### `get_download_url(seconds=60, key=None)` ####
 
-Returns a temp URL to the object specified by the URI to `get_storage`.
+Returns a download URL to the object specified by the URI to `get_storage`.
 This works for **swift** based protocols (e.g. **cloudfiles, hpcloud**) as
 well as for both local file storage objects and ftp storage objects.
 
@@ -84,9 +84,9 @@ different timeout can be specified by using the `seconds=` parameter.
 Note, that the container must already have a temp url key set for the container.
 If it does not have a temp url key, an exception will be raised.
 
-For local file storage, the call will return a URL formed by joining the `temp_url_base=`
+For local file storage, the call will return a URL formed by joining the `download_url_base=`
 that was included in the URI that was passed to `get_storage` with the object name. If no
-`temp_url_base=` query param was included in the storage URI, `get_temp_url` will return
+`download_url_base=` query param was included in the storage URI, `get_download_url` will return
 `None` instead. (*see* [**file**](#file) *below*)
 
 ### Supported Protocols ###
@@ -103,7 +103,7 @@ Example:
 
 ```
 
-file:///home/user/awesome-file.txt[?temp_url_base=<ENCODED-URL>]
+file:///home/user/awesome-file.txt[?download_url_base=<ENCODED-URL>]
 
 ```
 
@@ -111,16 +111,16 @@ If the intermediate directories specified in the URI passed to
 `get_storage` do not exist, the file-local storage object will attempt
 to create them when using `load_from_file` or `load_from_filename`.
 
-If a `temp_url_base=` is included in the URI specified to `get_storage`, `get_temp_url` will
-return a URL that that joins the `temp_url_base` with the object name.
+If a `download_url_base=` is included in the URI specified to `get_storage`, `get_download_url` will
+return a URL that that joins the `download_url_base` with the object name.
 
-For example, if a `temp_url_base` of (`http://hostname/some/path/`) is included in the URI:
+For example, if a `download_url_base` of (`http://hostname/some/path/`) is included in the URI:
 
 ```
-file:///home/user/awesome-file.txt?temp_url_base=http%3A%2F%2Fhostname%2Fsome%2Fpath%2F
+file:///home/user/awesome-file.txt?download_url_base=http%3A%2F%2Fhostname%2Fsome%2Fpath%2F
 ```
 
-then a call to `get_temp_url` will return:
+then a call to `get_download_url` will return:
 
 ```
 http://hostname/some/path/awesome-file.txt
@@ -160,7 +160,7 @@ accept the following optional parameters:
 |:----------------|:------------------------------------------------------------------------|
 | `public`        | Whether or not to use the internal ServiceNet network. This saves bandwidth if you are accessing CloudFiles from within the same datacenter.  (default: true)           |
 | `api_key`       | API key to be used during authentication.                               |
-| `temp_url_key`  | Key to be used when retrieving a temp url to the storage object from the **Swift** object store (see `get_temp_url()`)|
+| `temp_url_key`  | Key to be used when retrieving a temp download url to the storage object from the **Swift** object store (see `get_download_url()`)|
 
 
 #### cloudfiles ####
@@ -220,7 +220,7 @@ Example:
 
 ```
 
-ftp://username:password@my-ftp-server/directory/awesome-file.txt[?temp_url_base=<ENCODED-URL>]
+ftp://username:password@my-ftp-server/directory/awesome-file.txt[?download_url_base=<ENCODED-URL>]
 
 ```
 
@@ -232,7 +232,7 @@ A reference to a file on an FTP server, served using the FTPS
 Example:
 
 ```
-ftps://username:password@my-secure-ftp-server/directory/awesome-file.txt[?temp_url_base=<ENCODED-URL>]
+ftps://username:password@my-secure-ftp-server/directory/awesome-file.txt[?download_url_base=<ENCODED-URL>]
 ```
 
 ### retry ###

--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ Downloads the contents of the file specified by the URI to
 
 Deletes the file specified by the URI to `get_storage`
 
+#### `get_temp_url(seconds=60, key=None)` ####
+
+Returns a temp URL to the file specified by the URI to `get_storage`.
+This works for swift based protocols (e.g. cloudfiles, hpcloud) as
+well as for the local file storage.
+
+For swift (**OpenStack**) based protocols (**Cloudfiles, Hpcloud**),
+this will return a time-limited temporary URL which can be used to GET
+the object directly from the container in the object store. By default
+the URL will only be valid for 60 seconds, but a different timeout
+can be specified by using the `seconds=` parameter.  Note, that the
+container must already have a temp url key set for the container.
+
+For local file storage, the call will simply return the same URI
+that was passed to `get_storage`.  All params are ignored.
+
 ### Supported Protocols ###
 
 The following protocols are supported, and can be selected by
@@ -85,13 +101,31 @@ Example:
 
 ```
 
-file:///home/user/awesome-file.txt
+file:///home/user/awesome-file.txt[?temp_url_base=<ENCODED-URL>]
 
 ```
 
 If the intermediate directories specified in the URI passed to
 `get_storage` do not exist, the file-local storage object will attempt
 to create them when using `load_from_file` or `load_from_filename`.
+
+If a `temp_url_base=` is included in the URI specified to `get_storage`, `get_temp_url` will
+return a URL that that joins the `temp_url_base` with the object name.
+
+For example, if a `temp_url_base` of (`http://hostname/some/path/`) is included in the URI:
+
+```
+file:///home/user/awesome-file.txt?temp_url_base=http%3A%2F%2Fhostname%2Fsome%2Fpath%2F
+```
+
+then a call to `get_temp_url` will return:
+
+```
+http://hostname/some/path/awesome-file.txt
+```
+
+For local storage objects both the `seconds=` and `key=` params are ignored.
+
 
 #### swift ####
 
@@ -124,6 +158,7 @@ accept the following optional parameters:
 |:----------------|:------------------------------------------------------------------------|
 | `public`        | Whether or not to use the internal ServiceNet network. This saves bandwidth if you are accessing CloudFiles from within the same datacenter.  (default: true)           |
 | `api_key`       | API key to be used during authentication.                               |
+| `temp_url_key`  | Key to be used when retrieving a temp url to the storage object from the **Swift** object store (see `get_temp_url()`|
 
 
 #### cloudfiles ####
@@ -183,7 +218,7 @@ Example:
 
 ```
 
-ftp://username:password@my-ftp-server/directory/awesome-file.txt
+ftp://username:password@my-ftp-server/directory/awesome-file.txt[?temp_url_base=<ENCODED-URL>]
 
 ```
 
@@ -195,7 +230,7 @@ A reference to a file on an FTP server, served using the FTPS
 Example:
 
 ```
-ftps://username:password@my-secure-ftp-server/directory/awesome-file.txt
+ftps://username:password@my-secure-ftp-server/directory/awesome-file.txt[?temp_url_base=<ENCODED-URL>]
 ```
 
 ### retry ###

--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ well as for both local file storage objects and ftp storage objects.
 For **swift** based protocols, this will return a time-limited temporary
 URL which can be used to GET the object directly from the container in the
 object store. By default the URL will only be valid for 60 seconds, but a
-different timeout can be specified by using the `seconds=` parameter.
+different timeout can be specified by using the `seconds` parameter.
 Note, that the container must already have a temp url key set for the container.
 If it does not have a temp url key, an exception will be raised.
 
-For local file storage, the call will return a URL formed by joining the `download_url_base=`
-that was included in the URI that was passed to `get_storage` with the object name. If no
-`download_url_base=` query param was included in the storage URI, `get_download_url` will return
+For local file storage, the call will return a URL formed by joining the `download_url_base`
+(included in the URI that was passed to `get_storage`) with the object name. If no
+`download_url_base` query param was included in the storage URI, `get_download_url` will return
 `None` instead. (*see* [**file**](#file) *below*)
 
 ### Supported Protocols ###
@@ -111,7 +111,7 @@ If the intermediate directories specified in the URI passed to
 `get_storage` do not exist, the file-local storage object will attempt
 to create them when using `load_from_file` or `load_from_filename`.
 
-If a `download_url_base=` is included in the URI specified to `get_storage`, `get_download_url` will
+If a `download_url_base` is included in the URI specified to `get_storage`, `get_download_url` will
 return a URL that that joins the `download_url_base` with the object name.
 
 For example, if a `download_url_base` of (`http://hostname/some/path/`) is included in the URI:
@@ -126,7 +126,7 @@ then a call to `get_download_url` will return:
 http://hostname/some/path/awesome-file.txt
 ```
 
-For local storage objects both the `seconds=` and `key=` params are ignored.
+For local storage objects both the `seconds` and `key` parameters to `get_download_url` are ignored.
 
 
 #### swift ####

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If it does not have a temp url key, an exception will be raised.
 For local file storage, the call will return a URL formed by joining the `temp_url_base=`
 that was included in the URI that was passed to `get_storage` with the object name. If no
 `temp_url_base=` query param was included in the storage URI, `get_temp_url` will return
-`None` instead. (*see (file)[file] below*)
+`None` instead. (*see* [**file**](#file) *below*)
 
 ### Supported Protocols ###
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("requirements.txt") as requirements_file:
                           map(lambda r: r.strip(), requirements_file.readlines()))
 
 setup(name="object_storage",
-      version="0.4.1",
+      version="0.4.2",
       description="Python library for accessing files over various file transfer protocols.",
       url="https://github.com/ustudio/storage",
       packages=["storage"],

--- a/storage/storage.py
+++ b/storage/storage.py
@@ -128,19 +128,19 @@ class LocalStorage(Storage):
         :return:        the download url that can be used to access the storage object
         :raises:        DownloadUrlBaseUndefinedError
         """
-        return generate_download_url_from_base(self._download_url_base,
+        return _generate_download_url_from_base(self._download_url_base,
                 self._parsed_storage_uri.path.split('/')[-1])
 
 
-def generate_download_url_from_base(base, object):
-    """Generate a download url by joining the base with the storage object.
+def _generate_download_url_from_base(base, object_name):
+    """Generate a download url by joining the base with the storage object_name.
 
     If the base is not defined, raise an exception.
     """
     if base is None:
         raise DownloadUrlBaseUndefinedError("The storage uri has no download_url_base defined.")
 
-    return urlparse.urljoin(base, object)
+    return urlparse.urljoin(base, object_name)
 
 
 import pyrax
@@ -389,7 +389,7 @@ class FTPStorage(Storage):
         :return:        the download url that can be used to access the storage object
         :raises:        DownloadUrlBaseUndefinedError
         """
-        return generate_download_url_from_base(self._download_url_base,
+        return _generate_download_url_from_base(self._download_url_base,
             self._parsed_storage_uri.path.split('/')[-1])
 
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,6 +1,8 @@
 import mock
+import os.path
 import storage as storagelib
 import tempfile
+import urllib
 from unittest import TestCase
 from StringIO import StringIO
 
@@ -135,6 +137,67 @@ class TestLocalStorage(TestCase):
         mock_exists.assert_called_with("/foobar/is")
         self.assertEqual(0, mock_makedirs.call_count)
 
+    def test_local_storage_get_temp_url(self):
+        temp_input = tempfile.NamedTemporaryFile()
+        temp_input.write("FOOBAR")
+        temp_input.flush()
+
+        temp_url_base = "http://host:123/path/to/"
+        temp_url_base_encoded = urllib.quote_plus(temp_url_base)
+
+        storage_uri = "file://{fpath}?temp_url_base={temp_url_base}".format(
+            fpath=temp_input.name,
+            temp_url_base=temp_url_base_encoded)
+
+        out_storage = storagelib.get_storage(storage_uri)
+        temp_url = out_storage.get_temp_url()
+
+        self.assertEqual("http://host:123/path/to/{}".format(os.path.basename(temp_input.name)),
+            temp_url)
+
+    def test_local_storage_get_temp_url_ignores_args(self):
+        temp_input = tempfile.NamedTemporaryFile()
+        temp_input.write("FOOBAR")
+        temp_input.flush()
+
+        temp_url_base = "http://host:123/path/to/"
+        temp_url_base_encoded = urllib.quote_plus(temp_url_base)
+
+        storage_uri = "file://{fpath}?temp_url_base={temp_url_base}".format(
+            fpath=temp_input.name,
+            temp_url_base=temp_url_base_encoded)
+
+        out_storage = storagelib.get_storage(storage_uri)
+        temp_url = out_storage.get_temp_url(seconds=900)
+
+        self.assertEqual("http://host:123/path/to/{}".format(os.path.basename(temp_input.name)),
+            temp_url)
+
+        temp_url = out_storage.get_temp_url(key="secret")
+
+        self.assertEqual("http://host:123/path/to/{}".format(os.path.basename(temp_input.name)),
+            temp_url)
+
+    def test_local_storage_get_temp_url_returns_none_on_empty_base(self):
+        temp_input = tempfile.NamedTemporaryFile()
+        temp_input.write("FOOBAR")
+        temp_input.flush()
+
+        # blank temp_url_base
+        storage_uri = "file://{fpath}?temp_url_base=".format(fpath=temp_input.name)
+
+        out_storage = storagelib.get_storage(storage_uri)
+        temp_url = out_storage.get_temp_url()
+
+        self.assertIsNone(temp_url)
+
+        # no temp_url_base
+        storage_uri = "file://{fpath}".format(fpath=temp_input.name)
+        out_storage = storagelib.get_storage(storage_uri)
+        temp_url = out_storage.get_temp_url()
+
+        self.assertIsNone(temp_url)
+
 
 class TestSwiftStorage(TestCase):
 
@@ -148,7 +211,8 @@ class TestSwiftStorage(TestCase):
             "tenant_id": "1234567890",
             "auth_endpoint": "http://identity.server.com:1234/v2/",
             "api_key": "0987654321",
-            "public": True
+            "public": True,
+            "temp_url_key": "super_secret_key"
         }
 
     def _assert_login_correct(self, mock_create_context, username=None, password=None, region=None,
@@ -170,7 +234,7 @@ class TestSwiftStorage(TestCase):
 
         uri = "swift://%(username)s:%(password)s@%(container)s/%(file)s?" \
               "auth_endpoint=%(auth_endpoint)s&region=%(region)s&api_key=%(api_key)s" \
-              "&tenant_id=%(tenant_id)s" % self.params
+              "&tenant_id=%(tenant_id)s&temp_url_key=%(temp_url_key)s" % self.params
         storage = storagelib.get_storage(uri)
         storage.save_to_filename(temp_output.name)
 
@@ -363,6 +427,72 @@ class TestSwiftStorage(TestCase):
                                    password=self.params["password"], region=self.params["region"],
                                    tenant_id=self.params["tenant_id"], public=False)
         mock_swift.delete_object.assert_called_with(self.params["container"], self.params["file"])
+
+    @mock.patch("pyrax.create_context")
+    def test_swift_get_temp_url(self, mock_create_context):
+        mock_swift = mock_create_context.return_value.get_client.return_value
+
+        uri = "swift://%(username)s:%(password)s@%(container)s/%(file)s?" \
+              "auth_endpoint=%(auth_endpoint)s&region=%(region)s" \
+              "&tenant_id=%(tenant_id)s&temp_url_key=%(temp_url_key)s" % self.params
+        storage = storagelib.get_storage(uri)
+        storage.get_temp_url()
+
+        self._assert_login_correct(mock_create_context, username=self.params["username"],
+            password=self.params["password"], region=self.params["region"],
+            tenant_id=self.params["tenant_id"], public=True)
+        mock_swift.get_temp_url.assert_called_with(self.params["container"], self.params["file"],
+            seconds=60, method="GET", key="super_secret_key")
+
+    @mock.patch("pyrax.create_context")
+    def test_swift_get_temp_url_without_temp_url_key(self, mock_create_context):
+        mock_swift = mock_create_context.return_value.get_client.return_value
+
+        uri = "swift://%(username)s:%(password)s@%(container)s/%(file)s?" \
+              "auth_endpoint=%(auth_endpoint)s&region=%(region)s" \
+              "&tenant_id=%(tenant_id)s" % self.params
+        storage = storagelib.get_storage(uri)
+        storage.get_temp_url()
+
+        self._assert_login_correct(mock_create_context, username=self.params["username"],
+            password=self.params["password"], region=self.params["region"],
+            tenant_id=self.params["tenant_id"], public=True)
+        mock_swift.get_temp_url.assert_called_with(self.params["container"], self.params["file"],
+            seconds=60, method="GET", key=None)
+
+    @mock.patch("pyrax.create_context")
+    def test_swift_get_temp_url_with_override(self, mock_create_context):
+        mock_swift = mock_create_context.return_value.get_client.return_value
+
+        uri = "swift://%(username)s:%(password)s@%(container)s/%(file)s?" \
+              "auth_endpoint=%(auth_endpoint)s&region=%(region)s" \
+              "&tenant_id=%(tenant_id)s&temp_url_key=%(temp_url_key)s" % self.params
+        storage = storagelib.get_storage(uri)
+
+        storage.get_temp_url(key="NOT-THE-URI-KEY")
+
+        self._assert_login_correct(mock_create_context, username=self.params["username"],
+            password=self.params["password"], region=self.params["region"],
+            tenant_id=self.params["tenant_id"], public=True)
+        mock_swift.get_temp_url.assert_called_with(self.params["container"], self.params["file"],
+            seconds=60, method="GET", key="NOT-THE-URI-KEY")
+
+    @mock.patch("pyrax.create_context")
+    def test_swift_get_temp_url_with_non_default_expiration(self, mock_create_context):
+        mock_swift = mock_create_context.return_value.get_client.return_value
+
+        uri = "swift://%(username)s:%(password)s@%(container)s/%(file)s?" \
+              "auth_endpoint=%(auth_endpoint)s&region=%(region)s" \
+              "&tenant_id=%(tenant_id)s" % self.params
+        storage = storagelib.get_storage(uri)
+        storage.get_temp_url(seconds=10*60)
+
+        self._assert_login_correct(mock_create_context, username=self.params["username"],
+            password=self.params["password"], region=self.params["region"],
+            tenant_id=self.params["tenant_id"], public=True)
+        mock_swift.get_temp_url.assert_called_with(self.params["container"], self.params["file"],
+            seconds=600, method="GET", key=None)
+
 
 
 class TestRegisterSwiftProtocol(TestCase):
@@ -573,6 +703,33 @@ class TestFTPStorage(TestCase):
 
         mock_ftp.cwd.assert_called_with("some/dir")
         mock_ftp.delete.assert_called_with("file")
+
+    @mock.patch("ftplib.FTP", autospec=True)
+    def test_get_temp_url(self, mock_ftp_class):
+        mock_ftp = mock_ftp_class.return_value
+
+        temp_url_base = urllib.quote_plus("http://hostname/path/to/")
+
+        ftpuri = "ftp://user:password@ftp.foo.com/some/dir/file.txt?temp_url_base={0}".format(
+            temp_url_base)
+
+        storage = storagelib.get_storage(ftpuri)
+        temp_url = storage.get_temp_url()
+
+        self.assertFalse(mock_ftp_class.called)
+        self.assertEqual(temp_url, "http://hostname/path/to/file.txt")
+
+    @mock.patch("ftplib.FTP", autospec=True)
+    def test_get_temp_url_returns_none_with_empty_base(self, mock_ftp_class):
+        mock_ftp = mock_ftp_class.return_value
+
+        ftpuri = "ftp://user:password@ftp.foo.com/some/dir/file.txt"
+
+        storage = storagelib.get_storage(ftpuri)
+        temp_url = storage.get_temp_url()
+
+        self.assertFalse(mock_ftp_class.called)
+        self.assertIsNone(temp_url)
 
 
 class TestFTPSStorage(TestCase):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,6 +1,7 @@
 import mock
 import os.path
 import storage as storagelib
+from storage.storage import DownloadUrlBaseUndefinedError
 import tempfile
 import urllib
 from unittest import TestCase
@@ -187,16 +188,16 @@ class TestLocalStorage(TestCase):
         storage_uri = "file://{fpath}?download_url_base=".format(fpath=temp_input.name)
 
         out_storage = storagelib.get_storage(storage_uri)
-        temp_url = out_storage.get_download_url()
 
-        self.assertIsNone(temp_url)
+        with self.assertRaises(DownloadUrlBaseUndefinedError):
+            temp_url = out_storage.get_download_url()
 
         # no download_url_base
         storage_uri = "file://{fpath}".format(fpath=temp_input.name)
         out_storage = storagelib.get_storage(storage_uri)
-        temp_url = out_storage.get_download_url()
 
-        self.assertIsNone(temp_url)
+        with self.assertRaises(DownloadUrlBaseUndefinedError):
+            temp_url = out_storage.get_download_url()
 
 
 class TestSwiftStorage(TestCase):
@@ -726,10 +727,11 @@ class TestFTPStorage(TestCase):
         ftpuri = "ftp://user:password@ftp.foo.com/some/dir/file.txt"
 
         storage = storagelib.get_storage(ftpuri)
-        temp_url = storage.get_download_url()
+
+        with self.assertRaises(DownloadUrlBaseUndefinedError):
+            temp_url = storage.get_download_url()
 
         self.assertFalse(mock_ftp_class.called)
-        self.assertIsNone(temp_url)
 
 
 class TestFTPSStorage(TestCase):


### PR DESCRIPTION
@ustudio/dev   please review...

- add support for retrieving a `get_download_url()` to
  - swift / cloudfiles / hpcloud storage objects
    - supports specifying `temp_url_key=` query param
  - local / ftp / ftps storage objects
    - supports specifying `download_url_base=` query param
- updated `README.md` with documentation
- updated `setup.py`
  - bumps `object_storage` version to 0.4.2