### PR TITLE
fixed reference to misnamed pyrax function

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install via pip:
 pip install object_storage
 ```
 
-The current version is `0.4.1`.
+The current version is `0.5.1`.
 
 ## Quick Start ##
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("requirements.txt") as requirements_file:
                           map(lambda r: r.strip(), requirements_file.readlines()))
 
 setup(name="object_storage",
-      version="0.4.2",
+      version="0.5.1",
       description="Python library for accessing files over various file transfer protocols.",
       url="https://github.com/ustudio/storage",
       packages=["storage"],

--- a/storage/storage.py
+++ b/storage/storage.py
@@ -246,7 +246,7 @@ class SwiftStorage(Storage):
         container_name, object_name = self._get_container_and_object_names()
         temp_url_key = key if key is not None else self.download_url_key
 
-        return self._cloudfiles.get_download_url(container_name, object_name, seconds=seconds,
+        return self._cloudfiles.get_temp_url(container_name, object_name, seconds=seconds,
             method="GET", key=temp_url_key)
 
 def register_swift_protocol(scheme, auth_endpoint):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -442,7 +442,7 @@ class TestSwiftStorage(TestCase):
         self._assert_login_correct(mock_create_context, username=self.params["username"],
             password=self.params["password"], region=self.params["region"],
             tenant_id=self.params["tenant_id"], public=True)
-        mock_swift.get_download_url.assert_called_with(self.params["container"], self.params["file"],
+        mock_swift.get_temp_url.assert_called_with(self.params["container"], self.params["file"],
             seconds=60, method="GET", key="super_secret_key")
 
     @mock.patch("pyrax.create_context")
@@ -458,7 +458,7 @@ class TestSwiftStorage(TestCase):
         self._assert_login_correct(mock_create_context, username=self.params["username"],
             password=self.params["password"], region=self.params["region"],
             tenant_id=self.params["tenant_id"], public=True)
-        mock_swift.get_download_url.assert_called_with(self.params["container"], self.params["file"],
+        mock_swift.get_temp_url.assert_called_with(self.params["container"], self.params["file"],
             seconds=60, method="GET", key=None)
 
     @mock.patch("pyrax.create_context")
@@ -475,7 +475,7 @@ class TestSwiftStorage(TestCase):
         self._assert_login_correct(mock_create_context, username=self.params["username"],
             password=self.params["password"], region=self.params["region"],
             tenant_id=self.params["tenant_id"], public=True)
-        mock_swift.get_download_url.assert_called_with(self.params["container"], self.params["file"],
+        mock_swift.get_temp_url.assert_called_with(self.params["container"], self.params["file"],
             seconds=60, method="GET", key="NOT-THE-URI-KEY")
 
     @mock.patch("pyrax.create_context")
@@ -491,7 +491,7 @@ class TestSwiftStorage(TestCase):
         self._assert_login_correct(mock_create_context, username=self.params["username"],
             password=self.params["password"], region=self.params["region"],
             tenant_id=self.params["tenant_id"], public=True)
-        mock_swift.get_download_url.assert_called_with(self.params["container"], self.params["file"],
+        mock_swift.get_temp_url.assert_called_with(self.params["container"], self.params["file"],
             seconds=600, method="GET", key=None)
 
 


### PR DESCRIPTION
@ustudio/dev  please review...

- `get_download_url()` should have been `get_temp_url()`
- bumped version to 0.5.1
  - 0.5.0 should have been the previous change with new feature
  - this fix would make it 0.5.1