### PR TITLE
Fix `get_download_url()` to urlencode filenames with spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install via pip:
 pip install object_storage
 ```
 
-The current version is `0.5.1`.
+The current version is `0.5.2`.
 
 ## Quick Start ##
 

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ If it does not have a temp url key, an exception will be raised.
 
 For local file storage, the call will return a URL formed by joining the `download_url_base`
 (included in the URI that was passed to `get_storage`) with the object name. If no
-`download_url_base` query param was included in the storage URI, `get_download_url` will return
-`None` instead. (*see* [**file**](#file) *below*)
+`download_url_base` query param was included in the storage URI, `get_download_url`
+will raise a `DownloadUrlBaseUndefinedError` exception. (*see* [**file**](#file) *below*)
 
 ### Supported Protocols ###
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("requirements.txt") as requirements_file:
                           map(lambda r: r.strip(), requirements_file.readlines()))
 
 setup(name="object_storage",
-      version="0.5.1",
+      version="0.5.2",
       description="Python library for accessing files over various file transfer protocols.",
       url="https://github.com/ustudio/storage",
       packages=["storage"],

--- a/storage/storage.py
+++ b/storage/storage.py
@@ -4,6 +4,7 @@ import mimetypes
 import os
 import os.path
 import shutil
+import urllib
 import urlparse
 
 _STORAGE_TYPES = {}         # maintains supported storage protocols
@@ -246,8 +247,13 @@ class SwiftStorage(Storage):
         container_name, object_name = self._get_container_and_object_names()
         temp_url_key = key if key is not None else self.download_url_key
 
-        return self._cloudfiles.get_temp_url(container_name, object_name, seconds=seconds,
-            method="GET", key=temp_url_key)
+        download_url = self._cloudfiles.get_temp_url(
+            container_name, object_name, seconds=seconds, method="GET", key=temp_url_key)
+
+        parsed_url = urlparse.urlparse(download_url)
+        parsed_url = parsed_url._replace(path=urllib.quote(parsed_url.path))
+
+        return urlparse.urlunparse(parsed_url)
 
 def register_swift_protocol(scheme, auth_endpoint):
     """Register a Swift based storage protocol under the specified scheme."""


### PR DESCRIPTION
@ustudio/dev  please review...

- modified `get_download_url()` to urlencode filenames containing
  spaces in them.  this is done AFTER the temp url is returned
  from pyrax because `pyrax.get_temp_url()` uses the original
  filename in signing the generated temp url.
- bumped version number for storage library