### PR TITLE
S3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,12 +215,14 @@ as defined by HP.
 ### Amazon S3 ###
 
 A reference to an object in an Amazon S3 bucket.  The `s3` scheme can be used when storing
-files using the Amazon S3 service. 
+files using the Amazon S3 service.
 
 A `region` parameter is not required, but can be specified.
 
-**NOTE:** Currently the storage library does not do chunked downloading of a file so it should
-not be used with large files.
+**NOTE:** Chunked transfer encoding is only used for
+`save_to_filename` and `load_from_filename`. If you use `save_to_file`
+or `load_from_file`, the entire contents of the file will be loaded
+into memory.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -217,11 +217,16 @@ as defined by HP.
 A reference to an object in an Amazon S3 bucket.  The `s3` scheme can be used when storing
 files using the Amazon S3 service. 
 
+A `region` parameter is not required, but can be specified.
+
+**NOTE:** Currently the storage library does not do chunked downloading of a file so it should
+not be used with large files.
+
 Example:
 
 ```
 
-s3://aws_access_key_id:aws_secret_access_key@bucket/path/to/file
+s3://aws_access_key_id:aws_secret_access_key@bucket/path/to/file[?region=us-west-2]
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install via pip:
 pip install object_storage
 ```
 
-The current version is `0.5.3`.
+The current version is `0.6.0`.
 
 ## Quick Start ##
 
@@ -211,6 +211,20 @@ preregistered authentication endpoint.  As with the [**swift**](#swift) scheme, 
 and `tenant_id` parameters must be specified. The `tenant_id` is typically the **Project Id**,
 as defined by HP.
 
+
+### Amazon S3 ###
+
+A reference to an object in an Amazon S3 bucket.  The `s3` scheme can be used when storing
+files using the Amazon S3 service. 
+
+Example:
+
+```
+
+s3://aws_access_key_id:aws_secret_access_key@bucket/path/to/file
+
+
+```
 
 ### ftp ####
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,10 @@
 Babel==1.3
+boto3==1.0.1
+botocore==1.0.1
+docutils==0.12
+futures==2.2.0
 iso8601==0.1.10
+jmespath==0.7.1
 keyring==3.8
 mock==1.0.1
 nose==1.3.3
@@ -9,6 +14,7 @@ os-virtual-interfacesv2-python-novaclient-ext==0.15
 pbr==0.10.0
 prettytable==0.7.2
 pyrax==1.9.2
+python-dateutil==2.4.2
 python-novaclient==2.18.1
 pytz==2014.4
 rackspace-auth-openstack==1.3

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("requirements.txt") as requirements_file:
                           map(lambda r: r.strip(), requirements_file.readlines()))
 
 setup(name="object_storage",
-      version="0.5.3",
+      version="0.6.0",
       description="Python library for accessing files over various file transfer protocols.",
       url="https://github.com/ustudio/storage",
       packages=["storage"],

--- a/storage/storage.py
+++ b/storage/storage.py
@@ -455,7 +455,10 @@ class S3Storage(Storage):
         bucket.put_object(Key=self._keyname, Body=in_file)
 
     def delete(self):
-        raise NotImplementedError("{0} does not implement 'delete'".format(self._class_name()))
+        bucket = self._connect()
+        obj = bucket.Object(self._keyname)
+
+        obj.delete()
 
     def get_download_url(self, seconds=60, key=None):
         raise NotImplementedError("{0} does not implement 'get_download_url'".format(self._class_name()))

--- a/storage/storage.py
+++ b/storage/storage.py
@@ -435,7 +435,7 @@ class S3Storage(Storage):
         return s3.Bucket(self._bucket)
 
     def save_to_filename(self, file_path):
-        with open(file_path) as out_file:
+        with open(file_path, "wb") as out_file:
             self.save_to_file(out_file)
 
     def save_to_file(self, out_file):

--- a/storage/storage.py
+++ b/storage/storage.py
@@ -446,7 +446,7 @@ class S3Storage(Storage):
         out_file.write(response["Body"].read())
 
     def load_from_filename(self, file_path):
-        with open(file_path) as in_file:
+        with open(file_path, "rb") as in_file:
             self.load_from_file(in_file)
 
     def load_from_file(self, in_file):

--- a/storage/storage.py
+++ b/storage/storage.py
@@ -435,12 +435,15 @@ class S3Storage(Storage):
         return s3.Bucket(self._bucket)
 
     def save_to_filename(self, file_path):
-        raise NotImplementedError(
-            "{0} does not implement 'save_to_filename'".format(self._class_name()))
+        with open(file_path) as out_file:
+            self.save_to_file(out_file)
 
     def save_to_file(self, out_file):
-        raise NotImplementedError(
-            "{0} does not implement 'save_to_file'".format(self._class_name()))
+        bucket = self._connect()
+        obj = bucket.Object(self._keyname)
+
+        response = obj.get()
+        out_file.write(response["Body"].read())
 
     def load_from_filename(self, file_path):
         with open(file_path) as in_file:

--- a/storage/storage.py
+++ b/storage/storage.py
@@ -130,8 +130,8 @@ class LocalStorage(Storage):
         :return:        the download url that can be used to access the storage object
         :raises:        DownloadUrlBaseUndefinedError
         """
-        return _generate_download_url_from_base(self._download_url_base,
-                self._parsed_storage_uri.path.split('/')[-1])
+        return _generate_download_url_from_base(
+            self._download_url_base, self._parsed_storage_uri.path.split('/')[-1])
 
 
 def _generate_download_url_from_base(base, object_name):
@@ -397,8 +397,8 @@ class FTPStorage(Storage):
         :return:        the download url that can be used to access the storage object
         :raises:        DownloadUrlBaseUndefinedError
         """
-        return _generate_download_url_from_base(self._download_url_base,
-            self._parsed_storage_uri.path.split('/')[-1])
+        return _generate_download_url_from_base(
+            self._download_url_base, self._parsed_storage_uri.path.split('/')[-1])
 
 
 @register_storage_protocol("ftps")

--- a/storage/storage.py
+++ b/storage/storage.py
@@ -1,4 +1,5 @@
 import boto3
+import boto3.s3.transfer
 import ftplib
 import functools
 import mimetypes
@@ -434,8 +435,10 @@ class S3Storage(Storage):
         return aws_session.client("s3")
 
     def save_to_filename(self, file_path):
-        with open(file_path, "wb") as out_file:
-            self.save_to_file(out_file)
+        client = self._connect()
+
+        transfer = boto3.s3.transfer.S3Transfer(client)
+        transfer.download_file(self._bucket, self._keyname, file_path)
 
     def save_to_file(self, out_file):
         client = self._connect()
@@ -444,8 +447,10 @@ class S3Storage(Storage):
         out_file.write(response["Body"].read())
 
     def load_from_filename(self, file_path):
-        with open(file_path, "rb") as in_file:
-            self.load_from_file(in_file)
+        client = self._connect()
+
+        transfer = boto3.s3.transfer.S3Transfer(client)
+        transfer.upload_file(file_path, self._bucket, self._keyname)
 
     def load_from_file(self, in_file):
         client = self._connect()

--- a/storage/storage.py
+++ b/storage/storage.py
@@ -418,8 +418,8 @@ class FTPSStorage(FTPStorage):
 class S3Storage(Storage):
     def __init__(self, storage_uri):
         super(S3Storage, self).__init__(storage_uri)
-        self._access_key = self._parsed_storage_uri.username
-        self._access_secret = self._parsed_storage_uri.password
+        self._access_key = urllib.unquote(self._parsed_storage_uri.username)
+        self._access_secret = urllib.unquote(self._parsed_storage_uri.password)
         self._bucket = self._parsed_storage_uri.hostname
         self._keyname = self._parsed_storage_uri.path.replace("/", "", 1)
 

--- a/storage/storage.py
+++ b/storage/storage.py
@@ -431,18 +431,16 @@ class S3Storage(Storage):
             aws_secret_access_key=self._access_secret,
             region_name=self._region)
 
-        s3 = aws_session.resource("s3")
-        return s3.Bucket(self._bucket)
+        return aws_session.client("s3")
 
     def save_to_filename(self, file_path):
         with open(file_path, "wb") as out_file:
             self.save_to_file(out_file)
 
     def save_to_file(self, out_file):
-        bucket = self._connect()
-        obj = bucket.Object(self._keyname)
+        client = self._connect()
 
-        response = obj.get()
+        response = client.get_object(Bucket=self._bucket, Key=self._keyname)
         out_file.write(response["Body"].read())
 
     def load_from_filename(self, file_path):
@@ -450,18 +448,18 @@ class S3Storage(Storage):
             self.load_from_file(in_file)
 
     def load_from_file(self, in_file):
-        bucket = self._connect()
+        client = self._connect()
 
-        bucket.put_object(Key=self._keyname, Body=in_file)
+        client.put_object(Bucket=self._bucket, Key=self._keyname, Body=in_file)
 
     def delete(self):
-        bucket = self._connect()
-        obj = bucket.Object(self._keyname)
+        client = self._connect()
 
-        obj.delete()
+        client.delete_object(Bucket=self._bucket, Key=self._keyname)
 
     def get_download_url(self, seconds=60, key=None):
-        raise NotImplementedError("{0} does not implement 'get_download_url'".format(self._class_name()))
+        raise NotImplementedError(
+            "{0} does not implement 'get_download_url'".format(self._class_name()))
 
 
 def get_storage(storage_uri):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -954,7 +954,7 @@ class TestS3Storage(TestCase):
 
         mock_s3.Bucket.assert_called_with("bucket")
 
-        mock_open.assert_called_with("source/file")
+        mock_open.assert_called_with("source/file", "rb")
 
         mock_bucket.put_object.assert_called_with(Key="some/file", Body=mock_file)
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -153,8 +153,8 @@ class TestLocalStorage(TestCase):
         out_storage = storagelib.get_storage(storage_uri)
         temp_url = out_storage.get_download_url()
 
-        self.assertEqual("http://host:123/path/to/{}".format(os.path.basename(temp_input.name)),
-            temp_url)
+        self.assertEqual(
+            "http://host:123/path/to/{}".format(os.path.basename(temp_input.name)), temp_url)
 
     def test_local_storage_get_download_url_ignores_args(self):
         temp_input = tempfile.NamedTemporaryFile()
@@ -171,13 +171,13 @@ class TestLocalStorage(TestCase):
         out_storage = storagelib.get_storage(storage_uri)
         temp_url = out_storage.get_download_url(seconds=900)
 
-        self.assertEqual("http://host:123/path/to/{}".format(os.path.basename(temp_input.name)),
-            temp_url)
+        self.assertEqual(
+            "http://host:123/path/to/{}".format(os.path.basename(temp_input.name)), temp_url)
 
         temp_url = out_storage.get_download_url(key="secret")
 
-        self.assertEqual("http://host:123/path/to/{}".format(os.path.basename(temp_input.name)),
-            temp_url)
+        self.assertEqual(
+            "http://host:123/path/to/{}".format(os.path.basename(temp_input.name)), temp_url)
 
     def test_local_storage_get_download_url_returns_none_on_empty_base(self):
         temp_input = tempfile.NamedTemporaryFile()
@@ -190,14 +190,14 @@ class TestLocalStorage(TestCase):
         out_storage = storagelib.get_storage(storage_uri)
 
         with self.assertRaises(DownloadUrlBaseUndefinedError):
-            temp_url = out_storage.get_download_url()
+            out_storage.get_download_url()
 
         # no download_url_base
         storage_uri = "file://{fpath}".format(fpath=temp_input.name)
         out_storage = storagelib.get_storage(storage_uri)
 
         with self.assertRaises(DownloadUrlBaseUndefinedError):
-            temp_url = out_storage.get_download_url()
+            out_storage.get_download_url()
 
 
 class TestSwiftStorage(TestCase):
@@ -439,10 +439,12 @@ class TestSwiftStorage(TestCase):
         storage = storagelib.get_storage(uri)
         storage.get_download_url()
 
-        self._assert_login_correct(mock_create_context, username=self.params["username"],
+        self._assert_login_correct(
+            mock_create_context, username=self.params["username"],
             password=self.params["password"], region=self.params["region"],
             tenant_id=self.params["tenant_id"], public=True)
-        mock_swift.get_temp_url.assert_called_with(self.params["container"], self.params["file"],
+        mock_swift.get_temp_url.assert_called_with(
+            self.params["container"], self.params["file"],
             seconds=60, method="GET", key="super_secret_key")
 
     @mock.patch("pyrax.create_context")
@@ -455,10 +457,12 @@ class TestSwiftStorage(TestCase):
         storage = storagelib.get_storage(uri)
         storage.get_download_url()
 
-        self._assert_login_correct(mock_create_context, username=self.params["username"],
+        self._assert_login_correct(
+            mock_create_context, username=self.params["username"],
             password=self.params["password"], region=self.params["region"],
             tenant_id=self.params["tenant_id"], public=True)
-        mock_swift.get_temp_url.assert_called_with(self.params["container"], self.params["file"],
+        mock_swift.get_temp_url.assert_called_with(
+            self.params["container"], self.params["file"],
             seconds=60, method="GET", key=None)
 
     @mock.patch("pyrax.create_context")
@@ -472,10 +476,12 @@ class TestSwiftStorage(TestCase):
 
         storage.get_download_url(key="NOT-THE-URI-KEY")
 
-        self._assert_login_correct(mock_create_context, username=self.params["username"],
+        self._assert_login_correct(
+            mock_create_context, username=self.params["username"],
             password=self.params["password"], region=self.params["region"],
             tenant_id=self.params["tenant_id"], public=True)
-        mock_swift.get_temp_url.assert_called_with(self.params["container"], self.params["file"],
+        mock_swift.get_temp_url.assert_called_with(
+            self.params["container"], self.params["file"],
             seconds=60, method="GET", key="NOT-THE-URI-KEY")
 
     @mock.patch("pyrax.create_context")
@@ -486,12 +492,14 @@ class TestSwiftStorage(TestCase):
               "auth_endpoint=%(auth_endpoint)s&region=%(region)s" \
               "&tenant_id=%(tenant_id)s" % self.params
         storage = storagelib.get_storage(uri)
-        storage.get_download_url(seconds=10*60)
+        storage.get_download_url(seconds=10 * 60)
 
-        self._assert_login_correct(mock_create_context, username=self.params["username"],
+        self._assert_login_correct(
+            mock_create_context, username=self.params["username"],
             password=self.params["password"], region=self.params["region"],
             tenant_id=self.params["tenant_id"], public=True)
-        mock_swift.get_temp_url.assert_called_with(self.params["container"], self.params["file"],
+        mock_swift.get_temp_url.assert_called_with(
+            self.params["container"], self.params["file"],
             seconds=600, method="GET", key=None)
 
     @mock.patch("pyrax.create_context")
@@ -759,8 +767,6 @@ class TestFTPStorage(TestCase):
 
     @mock.patch("ftplib.FTP", autospec=True)
     def test_get_download_url(self, mock_ftp_class):
-        mock_ftp = mock_ftp_class.return_value
-
         download_url_base = urllib.quote_plus("http://hostname/path/to/")
 
         ftpuri = "ftp://user:password@ftp.foo.com/some/dir/file.txt?download_url_base={0}".format(
@@ -774,14 +780,12 @@ class TestFTPStorage(TestCase):
 
     @mock.patch("ftplib.FTP", autospec=True)
     def test_get_download_url_returns_none_with_empty_base(self, mock_ftp_class):
-        mock_ftp = mock_ftp_class.return_value
-
         ftpuri = "ftp://user:password@ftp.foo.com/some/dir/file.txt"
 
         storage = storagelib.get_storage(ftpuri)
 
         with self.assertRaises(DownloadUrlBaseUndefinedError):
-            temp_url = storage.get_download_url()
+            storage.get_download_url()
 
         self.assertFalse(mock_ftp_class.called)
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -957,3 +957,72 @@ class TestS3Storage(TestCase):
         mock_open.assert_called_with("source/file")
 
         mock_bucket.put_object.assert_called_with(Key="some/file", Body=mock_file)
+
+    @mock.patch("boto3.session.Session", autospec=True)
+    def test_save_to_file(self, mock_session_class):
+        mock_session = mock_session_class.return_value
+        mock_s3 = mock_session.resource.return_value
+        mock_bucket = mock_s3.Bucket.return_value
+        mock_object = mock_bucket.Object.return_value
+
+        mock_body = mock.Mock()
+        mock_body.read.return_value = b"some file contents"
+        mock_object.get.return_value = {
+            "Body": mock_body
+        }
+
+        mock_file = mock.Mock()
+
+        storage = storagelib.get_storage(
+            "s3://access_key:access_secret@bucket/some/file?region=US_EAST")
+
+        storage.save_to_file(mock_file)
+
+        mock_session_class.assert_called_with(
+            aws_access_key_id="access_key",
+            aws_secret_access_key="access_secret",
+            region_name="US_EAST")
+
+        mock_session.resource.assert_called_with("s3")
+
+        mock_s3.Bucket.assert_called_with("bucket")
+        mock_bucket.Object.assert_called_with("some/file")
+
+        mock_object.get.assert_called_with()
+        mock_file.write.assert_called_with(b"some file contents")
+
+    @mock.patch("__builtin__.open", autospec=True)
+    @mock.patch("boto3.session.Session", autospec=True)
+    def test_save_to_filename(self, mock_session_class, mock_open):
+        mock_session = mock_session_class.return_value
+        mock_s3 = mock_session.resource.return_value
+        mock_bucket = mock_s3.Bucket.return_value
+        mock_object = mock_bucket.Object.return_value
+
+        mock_body = mock.Mock()
+        mock_body.read.return_value = b"some file contents"
+        mock_object.get.return_value = {
+            "Body": mock_body
+        }
+
+        mock_file = mock_open.return_value.__enter__.return_value
+
+        storage = storagelib.get_storage(
+            "s3://access_key:access_secret@bucket/some/file?region=US_EAST")
+
+        storage.save_to_filename("destination/file")
+
+        mock_session_class.assert_called_with(
+            aws_access_key_id="access_key",
+            aws_secret_access_key="access_secret",
+            region_name="US_EAST")
+
+        mock_session.resource.assert_called_with("s3")
+
+        mock_s3.Bucket.assert_called_with("bucket")
+        mock_bucket.Object.assert_called_with("some/file")
+
+        mock_open.assert_called_with("destination/file")
+
+        mock_object.get.assert_called_with()
+        mock_file.write.assert_called_with(b"some file contents")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1022,7 +1022,7 @@ class TestS3Storage(TestCase):
         mock_s3.Bucket.assert_called_with("bucket")
         mock_bucket.Object.assert_called_with("some/file")
 
-        mock_open.assert_called_with("destination/file")
+        mock_open.assert_called_with("destination/file", "wb")
 
         mock_object.get.assert_called_with()
         mock_file.write.assert_called_with(b"some file contents")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -908,6 +908,21 @@ class TestFTPSStorage(TestCase):
 
 class TestS3Storage(TestCase):
     @mock.patch("boto3.session.Session", autospec=True)
+    def test_handles_urlencoded_keys(self, mock_session_class):
+        encoded_key = urllib.quote("access/key", safe="")
+        encoded_secret = urllib.quote("access/secret", safe="")
+
+        storage = storagelib.get_storage(
+            "s3://{0}:{1}@bucket/some/file?region=US_EAST".format(encoded_key, encoded_secret))
+
+        storage._connect()
+
+        mock_session_class.assert_called_with(
+            aws_access_key_id="access/key",
+            aws_secret_access_key="access/secret",
+            region_name="US_EAST")
+
+    @mock.patch("boto3.session.Session", autospec=True)
     def test_load_from_file(self, mock_session_class):
         mock_session = mock_session_class.return_value
         mock_s3 = mock_session.client.return_value

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -910,8 +910,7 @@ class TestS3Storage(TestCase):
     @mock.patch("boto3.session.Session", autospec=True)
     def test_load_from_file(self, mock_session_class):
         mock_session = mock_session_class.return_value
-        mock_s3 = mock_session.resource.return_value
-        mock_bucket = mock_s3.Bucket.return_value
+        mock_s3 = mock_session.client.return_value
 
         mock_file = mock.Mock()
 
@@ -925,18 +924,15 @@ class TestS3Storage(TestCase):
             aws_secret_access_key="access_secret",
             region_name="US_EAST")
 
-        mock_session.resource.assert_called_with("s3")
+        mock_session.client.assert_called_with("s3")
 
-        mock_s3.Bucket.assert_called_with("bucket")
-
-        mock_bucket.put_object.assert_called_with(Key="some/file", Body=mock_file)
+        mock_s3.put_object.assert_called_with(Bucket="bucket", Key="some/file", Body=mock_file)
 
     @mock.patch("__builtin__.open", autospec=True)
     @mock.patch("boto3.session.Session", autospec=True)
     def test_load_from_filename(self, mock_session_class, mock_open):
         mock_session = mock_session_class.return_value
-        mock_s3 = mock_session.resource.return_value
-        mock_bucket = mock_s3.Bucket.return_value
+        mock_s3 = mock_session.client.return_value
 
         mock_file = mock_open.return_value.__enter__.return_value
 
@@ -950,24 +946,20 @@ class TestS3Storage(TestCase):
             aws_secret_access_key="access_secret",
             region_name="US_EAST")
 
-        mock_session.resource.assert_called_with("s3")
-
-        mock_s3.Bucket.assert_called_with("bucket")
+        mock_session.client.assert_called_with("s3")
 
         mock_open.assert_called_with("source/file", "rb")
 
-        mock_bucket.put_object.assert_called_with(Key="some/file", Body=mock_file)
+        mock_s3.put_object.assert_called_with(Bucket="bucket", Key="some/file", Body=mock_file)
 
     @mock.patch("boto3.session.Session", autospec=True)
     def test_save_to_file(self, mock_session_class):
         mock_session = mock_session_class.return_value
-        mock_s3 = mock_session.resource.return_value
-        mock_bucket = mock_s3.Bucket.return_value
-        mock_object = mock_bucket.Object.return_value
+        mock_s3 = mock_session.client.return_value
 
         mock_body = mock.Mock()
         mock_body.read.return_value = b"some file contents"
-        mock_object.get.return_value = {
+        mock_s3.get_object.return_value = {
             "Body": mock_body
         }
 
@@ -983,25 +975,20 @@ class TestS3Storage(TestCase):
             aws_secret_access_key="access_secret",
             region_name="US_EAST")
 
-        mock_session.resource.assert_called_with("s3")
+        mock_session.client.assert_called_with("s3")
 
-        mock_s3.Bucket.assert_called_with("bucket")
-        mock_bucket.Object.assert_called_with("some/file")
-
-        mock_object.get.assert_called_with()
+        mock_s3.get_object.assert_called_with(Bucket="bucket", Key="some/file")
         mock_file.write.assert_called_with(b"some file contents")
 
     @mock.patch("__builtin__.open", autospec=True)
     @mock.patch("boto3.session.Session", autospec=True)
     def test_save_to_filename(self, mock_session_class, mock_open):
         mock_session = mock_session_class.return_value
-        mock_s3 = mock_session.resource.return_value
-        mock_bucket = mock_s3.Bucket.return_value
-        mock_object = mock_bucket.Object.return_value
+        mock_s3 = mock_session.client.return_value
 
         mock_body = mock.Mock()
         mock_body.read.return_value = b"some file contents"
-        mock_object.get.return_value = {
+        mock_s3.get_object.return_value = {
             "Body": mock_body
         }
 
@@ -1017,22 +1004,17 @@ class TestS3Storage(TestCase):
             aws_secret_access_key="access_secret",
             region_name="US_EAST")
 
-        mock_session.resource.assert_called_with("s3")
+        mock_session.client.assert_called_with("s3")
 
-        mock_s3.Bucket.assert_called_with("bucket")
-        mock_bucket.Object.assert_called_with("some/file")
+        mock_s3.get_object.assert_called_with(Bucket="bucket", Key="some/file")
 
         mock_open.assert_called_with("destination/file", "wb")
-
-        mock_object.get.assert_called_with()
         mock_file.write.assert_called_with(b"some file contents")
 
     @mock.patch("boto3.session.Session", autospec=True)
     def test_delete(self, mock_session_class):
         mock_session = mock_session_class.return_value
-        mock_s3 = mock_session.resource.return_value
-        mock_bucket = mock_s3.Bucket.return_value
-        mock_object = mock_bucket.Object.return_value
+        mock_s3 = mock_session.client.return_value
 
         storage = storagelib.get_storage(
             "s3://access_key:access_secret@bucket/some/file?region=US_EAST")
@@ -1044,8 +1026,6 @@ class TestS3Storage(TestCase):
             aws_secret_access_key="access_secret",
             region_name="US_EAST")
 
-        mock_session.resource.assert_called_with("s3")
+        mock_session.client.assert_called_with("s3")
 
-        mock_s3.Bucket.assert_called_with("bucket")
-        mock_bucket.Object.assert_called_with("some/file")
-        mock_object.delete.assert_called_once_with()
+        mock_s3.delete_object.assert_called_with(Bucket="bucket", Key="some/file")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1026,3 +1026,26 @@ class TestS3Storage(TestCase):
 
         mock_object.get.assert_called_with()
         mock_file.write.assert_called_with(b"some file contents")
+
+    @mock.patch("boto3.session.Session", autospec=True)
+    def test_delete(self, mock_session_class):
+        mock_session = mock_session_class.return_value
+        mock_s3 = mock_session.resource.return_value
+        mock_bucket = mock_s3.Bucket.return_value
+        mock_object = mock_bucket.Object.return_value
+
+        storage = storagelib.get_storage(
+            "s3://access_key:access_secret@bucket/some/file?region=US_EAST")
+
+        storage.delete()
+
+        mock_session_class.assert_called_with(
+            aws_access_key_id="access_key",
+            aws_secret_access_key="access_secret",
+            region_name="US_EAST")
+
+        mock_session.resource.assert_called_with("s3")
+
+        mock_s3.Bucket.assert_called_with("bucket")
+        mock_bucket.Object.assert_called_with("some/file")
+        mock_object.delete.assert_called_once_with()


### PR DESCRIPTION
@ustudio/dev please review

- adds `s3` support to storage library
  - all methods except for `get_download_url()` are covered
- bumps version number (in `setup.py` and `README.md` to 0.6.0)

**NOTE:**
Did not document the `?region=` query parameter availability since it appears that S3 does not require a region to be specified.  In fact, when I attempted to use `boto3` while specifying a `region_name=` I got an error when trying to retrieve the `"s3"` resource. 
