### PR TITLE
Add specific FTP port management

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,3 +5,4 @@ uStudio, Inc
     Ricardo Contreras
     Thomas Stephens
     Josh Marshall
+    Brice Grichy

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,4 +5,5 @@ uStudio, Inc
     Ricardo Contreras
     Thomas Stephens
     Josh Marshall
-    Brice Grichy
+
+Brice Grichy

--- a/storage/storage.py
+++ b/storage/storage.py
@@ -322,7 +322,7 @@ class FTPStorage(Storage):
         self._username = self._parsed_storage_uri.username
         self._password = self._parsed_storage_uri.password
         self._hostname = self._parsed_storage_uri.hostname
-        self._port = 21
+        self._port = self._parsed_storage_uri.port if self._parsed_storage_uri.port is not None else 21
         query = urlparse.parse_qs(self._parsed_storage_uri.query)
         self._download_url_base = query.get("download_url_base", [None])[0]
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -688,7 +688,7 @@ class TestFTPStorage(TestCase):
         self.assertEqual("RETR file", mock_ftp.retrbinary.call_args[0][0])
 
         self.assertEqual("foobar", out_file.getvalue())
-        
+ 
     @mock.patch("ftplib.FTP", autospec=True)
     def test_save_to_file_with_specific_port(self, mock_ftp_class):
         out_file = StringIO()
@@ -736,7 +736,7 @@ class TestFTPStorage(TestCase):
         mock_open.assert_called_with("some_file", "rb")
         mock_ftp.storbinary.assert_called_with(
             "STOR file", mock_open.return_value.__enter__.return_value)
-            
+ 
     @mock.patch("__builtin__.open", autospec=True)
     @mock.patch("ftplib.FTP", autospec=True)
     def test_load_from_filename_with_specific_port(self, mock_ftp_class, mock_open):


### PR DESCRIPTION
I propose to add specific port management with the FTP(s) protocols.
ftp[s]://username:password@host:port/path/to/file
If missing, 21 value is taken by default.

Unittests added and all pass after modification

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ustudio/storage/26)
<!-- Reviewable:end -->
