### PR TITLE
play-1029 - storage library should delete directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install via pip:
 pip install object_storage
 ```
 
-The current version is `0.7.2`.
+The current version is `0.7.3`.
 
 ## Quick Start ##
 
@@ -77,9 +77,20 @@ Downloads the contents of the file specified by the URI to
 Downloads the contents of the directory specified by the URI to
 `get_storage` into the directory at directory\_path.
 
-#### `delete()` ####
+#### `delete(recursive=False)` ####
 
-Deletes the file specified by the URI to `get_storage`
+Deletes the file specified by the URI to `get_storage`.
+
+If the target URI points to a directory structure -- as loaded by `load_from_directory()` --
+then the `recursive=True` parameter can be used to remove all of the contents under that URI.
+
+For example,
+
+```python
+storage_dir = get_storage("file:///path/to/directory")
+storage_dir.load_from_directory("/source/path/to/upload/directory")
+storage_dir.delete(recursive=True)
+```
 
 #### `get_download_url(seconds=60, key=None)` ####
 
@@ -220,6 +231,10 @@ s3://aws_access_key_id:aws_secret_access_key@bucket/path/to/file[?region=us-west
 
 
 ```
+
+Note that the `aws_access_key` and `aws_secret_access_key` should be URL encoded, to quote
+unsafe characters, if necessary. This may be necessary as AWS sometimes includes characters
+such as a `/`.
 
 ### ftp ####
 

--- a/README.md
+++ b/README.md
@@ -77,20 +77,14 @@ Downloads the contents of the file specified by the URI to
 Downloads the contents of the directory specified by the URI to
 `get_storage` into the directory at directory\_path.
 
-#### `delete(recursive=False)` ####
+#### `delete()` ####
 
 Deletes the file specified by the URI to `get_storage`.
 
-If the target URI points to a directory structure -- as loaded by `load_from_directory()` --
-then the `recursive=True` parameter can be used to remove all of the contents under that URI.
+#### `delete_directory()` ####
 
-For example,
+Recursively deletes the directory structure specified by the URI to `get_storage()`.
 
-```python
-storage_dir = get_storage("file:///path/to/directory")
-storage_dir.load_from_directory("/source/path/to/upload/directory")
-storage_dir.delete(recursive=True)
-```
 
 #### `get_download_url(seconds=60, key=None)` ####
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
 ]
 
 setup(name="object_storage",
-      version="0.7.2",
+      version="0.7.3",
       description="Python library for accessing files over various file transfer protocols.",
       url="https://github.com/ustudio/storage",
       packages=["storage"],

--- a/storage/storage.py
+++ b/storage/storage.py
@@ -319,10 +319,18 @@ class SwiftStorage(Storage):
                 self._upload_file(
                     os.path.join(root, file), object_path=os.path.join(container_path, file))
 
-    def delete(self):
+    def delete(self, recursive=False):
         self._authenticate()
         container_name, object_name = self._get_container_and_object_names()
-        self._cloudfiles.delete_object(container_name, object_name)
+
+        if not recursive:
+            self._cloudfiles.delete_object(container_name, object_name)
+        else:
+            # recursively find and delete all objects below object_name
+            _, objects = self._list_container_objects(container_name, object_name)
+
+            for obj in objects:
+                self._cloudfiles.delete_object(container_name, obj.name)
 
     def get_download_url(self, seconds=60, key=None):
         self._authenticate()

--- a/storage/storage.py
+++ b/storage/storage.py
@@ -70,7 +70,7 @@ class Storage(object):
         raise NotImplementedError(
             "{0} does not implement 'load_from_directory'".format(self._class_name()))
 
-    def delete(self):
+    def delete(self, recursive=False):
         raise NotImplementedError("{0} does not implement 'delete'".format(self._class_name()))
 
     def get_download_url(self, seconds=60, key=None):
@@ -128,8 +128,11 @@ class LocalStorage(Storage):
         self._ensure_exists()
         distutils.dir_util.copy_tree(source_directory, self._parsed_storage_uri.path)
 
-    def delete(self):
-        os.remove(self._parsed_storage_uri.path)
+    def delete(self, recursive=False):
+        if recursive:
+            shutil.rmtree(self._parsed_storage_uri.path, True)
+        else:
+            os.remove(self._parsed_storage_uri.path)
 
     def get_download_url(self, seconds=60, key=None):
         """

--- a/storage/storage.py
+++ b/storage/storage.py
@@ -132,7 +132,7 @@ class LocalStorage(Storage):
         self._ensure_exists()
         distutils.dir_util.copy_tree(source_directory, self._parsed_storage_uri.path)
 
-    def delete(self, recursive=False):
+    def delete(self):
         os.remove(self._parsed_storage_uri.path)
 
     def delete_directory(self):
@@ -563,6 +563,9 @@ class FTPStorage(Storage):
 
             directories_to_remove.append("/{}".format(root))
 
+        # delete directories _after_ removing files from directories
+        # directories should be removed in reverse order - leaf directories before
+        # parent directories - since there is no recursive delete
         directories_to_remove.sort(reverse=True)
         for directory in directories_to_remove:
             ftp_client.rmd("{}".format(directory))

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -199,12 +199,12 @@ class TestLocalStorage(TestCase):
 
     @mock.patch("shutil.rmtree", autospec=True)
     @mock.patch("os.remove", autospec=True)
-    def test_local_storage_delete_recursive(self, mock_remove, mock_rmtree):
+    def test_local_storage_delete_directory(self, mock_remove, mock_rmtree):
         temp_directory = create_temp_nested_directory_with_files()
 
         storage = storagelib.get_storage(
             "file://{0}".format(temp_directory["temp_directory"]["path"]))
-        storage.delete(recursive=True)
+        storage.delete_directory()
 
         self.assertFalse(mock_remove.called)
         mock_rmtree.assert_called_once_with(temp_directory["temp_directory"]["path"], True)
@@ -655,7 +655,7 @@ class TestSwiftStorage(TestCase):
         mock_swift.delete_object.assert_called_with(self.params["container"], self.params["file"])
 
     @mock.patch("pyrax.create_context")
-    def test_swift_delete_recursive(self, mock_create_context):
+    def test_swift_delete_directory(self, mock_create_context):
 
         expected_files = [
             self.RackspaceObject("file/a/0.txt", "text/plain"),
@@ -671,7 +671,7 @@ class TestSwiftStorage(TestCase):
               "&tenant_id={tenant_id}".format(**self.params)
 
         storage = storagelib.get_storage(uri)
-        storage.delete(recursive=True)
+        storage.delete_directory()
 
         mock_swift.delete_object.assert_has_calls([
             mock.call(self.params["container"], "file/a/b/c/2.mp4"),
@@ -1331,7 +1331,7 @@ class TestFTPStorage(TestCase):
         mock_ftp.delete.assert_called_with("file")
 
     @mock.patch("ftplib.FTP", autospec=True)
-    def test_ftp_delete_recursive(self, mock_ftp_class):
+    def test_ftp_delete_directory(self, mock_ftp_class):
         mock_ftp = mock_ftp_class.return_value
 
         mock_ftp.pwd.return_value = "some/dir/file"
@@ -1360,7 +1360,7 @@ class TestFTPStorage(TestCase):
         ])
 
         storage = storagelib.get_storage("ftp://user:password@ftp.foo.com/some/dir/file")
-        storage.delete(recursive=True)
+        storage.delete_directory()
 
         mock_ftp_class.assert_called_with()
         mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
@@ -1676,7 +1676,7 @@ class TestS3Storage(TestCase):
         mock_s3.delete_object.assert_called_with(Bucket="bucket", Key="some/file")
 
     @mock.patch("boto3.session.Session", autospec=True)
-    def test_delete_recursive(self, mock_session_class):
+    def test_delete_directory(self, mock_session_class):
         mock_session = mock_session_class.return_value
         mock_s3 = mock_session.client.return_value
 
@@ -1730,7 +1730,7 @@ class TestS3Storage(TestCase):
         storage = storagelib.get_storage(
             "s3://access_key:access_secret@bucket/some/dir")
 
-        storage.delete(recursive=True)
+        storage.delete_directory()
 
         mock_session_class.assert_called_with(
             aws_access_key_id="access_key",

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1143,6 +1143,180 @@ class TestFTPStorage(TestCase):
         mock_ftp.storbinary.assert_called_with("STOR file", in_file)
 
     @mock.patch("ftplib.FTP", autospec=True)
+    def test_ftp_load_from_directory_creates_directories_from_storage_URI_if_not_present(
+            self, mock_ftp_class):
+        mock_ftp = mock_ftp_class.return_value
+
+        mock_ftp.retrlines.return_value = []
+
+        storage = storagelib.get_storage("ftp://user:password@ftp.foo.com/some/dir/file")
+
+        # empty folder
+        storage.load_from_directory(tempfile.mkdtemp())
+
+        mock_ftp_class.assert_called_with()
+        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
+        mock_ftp.login.assert_called_with("user", "password")
+
+        mock_ftp.mkd.assert_has_calls([
+            mock.call("some"),
+            mock.call("dir"),
+            mock.call("file")
+        ])
+
+    @mock.patch("ftplib.FTP", autospec=True)
+    def test_ftp_load_from_directory_does_not_create_dirs_from_storage_URI_if_present(
+            self, mock_ftp_class):
+        mock_ftp = mock_ftp_class.return_value
+
+        mock_ftp.retrlines.side_effect = create_mock_ftp_directory_listing([
+            "drwxrwxr-x 3 test test 4.0K Apr  9 10:54 some",
+            "drwxrwxr-x 3 test test 4.0K Apr  9 10:54 dir",
+        ])
+
+        storage = storagelib.get_storage("ftp://user:password@ftp.foo.com/some/dir/file")
+
+        # empty folder
+        storage.load_from_directory(tempfile.mkdtemp())
+
+        mock_ftp_class.assert_called_with()
+        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
+        mock_ftp.login.assert_called_with("user", "password")
+        self.assertEqual(1, mock_ftp.mkd.call_count)
+        mock_ftp.mkd.assert_has_calls([mock.call("file")])
+        mock_ftp.cwd.assert_has_calls([
+            mock.call("some"),
+            mock.call("dir"),
+            mock.call("file")
+        ])
+
+    @mock.patch("ftplib.FTP", autospec=True)
+    def test_ftp_load_from_directory_create_dirs_from_load_directory(
+            self, mock_ftp_class):
+        mock_ftp = mock_ftp_class.return_value
+        mock_ftp.pwd.return_value = "pwd_return_value"
+        temp_directory = create_temp_nested_directory_with_files()
+
+        directory_listings = [
+            "drwxrwxr-x 3 test test 4.0K Apr  9 10:54 some",
+            "drwxrwxr-x 3 test test 4.0K Apr  9 10:54 dir",
+        ]
+
+        def get_directory_listing(_, callback):
+            if len(directory_listings):
+                return callback(directory_listings.pop(0))
+
+        mock_ftp.retrlines.side_effect = get_directory_listing
+
+        storage = storagelib.get_storage("ftp://user:password@ftp.foo.com/some/dir")
+
+        # empty folder
+        storage.load_from_directory(temp_directory["temp_directory"]["path"])
+
+        mock_ftp_class.assert_called_with()
+        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
+        mock_ftp.login.assert_called_with("user", "password")
+
+        mock_ftp.mkd.assert_has_calls([
+            mock.call(temp_directory["nested_temp_directory"]["name"])
+        ])
+
+        mock_ftp.cwd.assert_has_calls([
+            mock.call("some"),
+            mock.call("dir"),
+            mock.call("/some/dir"),
+            mock.call(temp_directory["nested_temp_directory"]["name"]),
+            mock.call("pwd_return_value"),
+            mock.call("/some/dir/" + temp_directory["nested_temp_directory"]["name"])
+        ])
+
+    @mock.patch("ftplib.FTP", autospec=True)
+    def test_ftp_load_from_directory_does_not_create_existing_dirs_from_load_directory(
+            self, mock_ftp_class):
+        mock_ftp = mock_ftp_class.return_value
+        mock_ftp.pwd.return_value = "pwd_return_value"
+        temp_directory = create_temp_nested_directory_with_files()
+
+        directory_listings = [
+            "drwxrwxr-x 3 test test 4.0K Apr  9 10:54 some",
+            "drwxrwxr-x 3 test test 4.0K Apr  9 10:54 dir",
+            "drwxrwxr-x 3 test test 4.0K Apr  9 10:54 {0}".format(
+                temp_directory["nested_temp_directory"]["name"]),
+        ]
+
+        def get_directory_listing(_, callback):
+            if len(directory_listings):
+                return callback(directory_listings.pop(0))
+
+        mock_ftp.retrlines.side_effect = get_directory_listing
+
+        storage = storagelib.get_storage("ftp://user:password@ftp.foo.com/some/dir")
+
+        # empty folder
+        storage.load_from_directory(temp_directory["temp_directory"]["path"])
+
+        mock_ftp_class.assert_called_with()
+        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
+        mock_ftp.login.assert_called_with("user", "password")
+        mock_ftp.mkd.assert_not_called()
+
+        mock_ftp.cwd.assert_has_calls([
+            mock.call("some"),
+            mock.call("dir"),
+            mock.call("/some/dir"),
+            mock.call(temp_directory["nested_temp_directory"]["name"]),
+            mock.call("pwd_return_value"),
+            mock.call("/some/dir/" + temp_directory["nested_temp_directory"]["name"])
+        ])
+
+    @mock.patch("__builtin__.open", autospec=True)
+    @mock.patch("ftplib.FTP", autospec=True)
+    def test_ftp_load_from_directory_creates_files_from_local_source_directory(
+            self, mock_ftp_class, mock_open):
+        mock_ftp = mock_ftp_class.return_value
+        mock_ftp.pwd.return_value = "pwd_return_value"
+        mock_open_return = mock_open.return_value.__enter__.return_value
+
+        temp_directory = create_temp_nested_directory_with_files()
+
+        directory_listings = [
+            "drwxrwxr-x 3 test test 4.0K Apr  9 10:54 {0}".format(
+                temp_directory["nested_temp_directory"]["name"]),
+        ]
+
+        def get_directory_listing(_, callback):
+            if len(directory_listings):
+                return callback(directory_listings.pop(0))
+
+        mock_ftp.retrlines.side_effect = get_directory_listing
+
+        storage = storagelib.get_storage("ftp://user:password@ftp.foo.com/dir")
+
+        # empty folder
+        storage.load_from_directory(temp_directory["temp_directory"]["path"])
+
+        mock_ftp_class.assert_called_with()
+        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
+        mock_ftp.login.assert_called_with("user", "password")
+
+        mock_ftp.storbinary.assert_has_calls([
+            mock.call(
+                "STOR {0}".format(temp_directory["temp_input_one"]["name"]), mock_open_return),
+            mock.call(
+                "STOR {0}".format(temp_directory["temp_input_two"]["name"]), mock_open_return),
+            mock.call(
+                "STOR {0}".format(temp_directory["nested_temp_input"]["name"]), mock_open_return)
+        ], any_order=True)
+
+        mock_ftp.cwd.assert_has_calls([
+            mock.call("dir"),
+            mock.call("/dir"),
+            mock.call(temp_directory["nested_temp_directory"]["name"]),
+            mock.call("pwd_return_value"),
+            mock.call("/dir/" + temp_directory["nested_temp_directory"]["name"])
+        ])
+
+    @mock.patch("ftplib.FTP", autospec=True)
     def test_ftp_delete(self, mock_ftp_class):
         mock_ftp = mock_ftp_class.return_value
 
@@ -1245,7 +1419,7 @@ class TestFTPStorage(TestCase):
 
 class TestFTPSStorage(TestCase):
     @mock.patch("ftplib.FTP_TLS", autospec=True)
-    def test_save_to_filename(self, mock_ftp_class):
+    def test_ftps_scheme_connects_using_ftp_lts_class(self, mock_ftp_lts_class):
         temp_output = tempfile.NamedTemporaryFile()
 
         mock_results = ["foo", "bar"]
@@ -1256,348 +1430,17 @@ class TestFTPSStorage(TestCase):
 
             return "226"
 
-        mock_ftp = mock_ftp_class.return_value
+        mock_ftp = mock_ftp_lts_class.return_value
         mock_ftp.retrbinary.side_effect = mock_retrbinary
 
         storage = storagelib.get_storage("ftps://user:password@ftp.foo.com/some/dir/file")
 
         storage.save_to_filename(temp_output.name)
 
-        mock_ftp_class.assert_called_with()
+        mock_ftp_lts_class.assert_called_with()
         mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
         mock_ftp.login.assert_called_with("user", "password")
         mock_ftp.prot_p.assert_called_with()
-
-        mock_ftp.cwd.assert_called_with("some/dir")
-        self.assertEqual(1, mock_ftp.retrbinary.call_count)
-        self.assertEqual("RETR file", mock_ftp.retrbinary.call_args[0][0])
-
-        with open(temp_output.name) as output_fp:
-            self.assertEqual("foobar", output_fp.read())
-
-    @mock.patch("ftplib.FTP_TLS", autospec=True)
-    def test_save_to_file(self, mock_ftp_class):
-        out_file = StringIO()
-
-        mock_results = ["foo", "bar"]
-
-        def mock_retrbinary(command, callback):
-            for chunk in mock_results:
-                callback(chunk)
-
-            return "226"
-
-        mock_ftp = mock_ftp_class.return_value
-        mock_ftp.retrbinary.side_effect = mock_retrbinary
-
-        storage = storagelib.get_storage("ftps://user:password@ftp.foo.com/some/dir/file")
-
-        storage.save_to_file(out_file)
-
-        mock_ftp_class.assert_called_with()
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
-        mock_ftp.prot_p.assert_called_with()
-
-        mock_ftp.cwd.assert_called_with("some/dir")
-        self.assertEqual(1, mock_ftp.retrbinary.call_count)
-        self.assertEqual("RETR file", mock_ftp.retrbinary.call_args[0][0])
-
-        self.assertEqual("foobar", out_file.getvalue())
-
-    @mock.patch("__builtin__.open", autospec=True)
-    @mock.patch("ftplib.FTP_TLS", autospec=True)
-    def test_load_from_filename(self, mock_ftp_class, mock_open):
-        mock_ftp = mock_ftp_class.return_value
-
-        storage = storagelib.get_storage("ftps://user:password@ftp.foo.com/some/dir/file")
-
-        storage.load_from_filename("some_file")
-
-        mock_ftp_class.assert_called_with()
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
-        mock_ftp.prot_p.assert_called_with()
-
-        mock_ftp.cwd.assert_called_with("some/dir")
-
-        mock_open.assert_called_with("some_file", "rb")
-        mock_ftp.storbinary.assert_called_with(
-            "STOR file", mock_open.return_value.__enter__.return_value)
-
-    @mock.patch("ftplib.FTP_TLS", autospec=True)
-    def test_load_from_file(self, mock_ftp_class):
-        mock_ftp = mock_ftp_class.return_value
-        in_file = StringIO("foobar")
-
-        storage = storagelib.get_storage("ftps://user:password@ftp.foo.com/some/dir/file")
-
-        storage.load_from_file(in_file)
-
-        mock_ftp_class.assert_called_with()
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
-        mock_ftp.prot_p.assert_called_with()
-
-        mock_ftp.cwd.assert_called_with("some/dir")
-
-        mock_ftp.storbinary.assert_called_with("STOR file", in_file)
-
-    @mock.patch("ftplib.FTP_TLS", autospec=True)
-    def test_ftp_load_from_directory_creates_directories_from_storage_URI_if_not_present(
-            self, mock_ftp_class):
-        mock_ftp = mock_ftp_class.return_value
-
-        mock_ftp.retrlines.return_value = []
-
-        storage = storagelib.get_storage("ftps://user:password@ftp.foo.com/some/dir/file")
-
-        # empty folder
-        storage.load_from_directory(tempfile.mkdtemp())
-
-        mock_ftp_class.assert_called_with()
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
-        mock_ftp.prot_p.assert_called_with()
-
-        mock_ftp.mkd.assert_has_calls([
-            mock.call("some"),
-            mock.call("dir"),
-            mock.call("file")
-        ])
-
-    @mock.patch("ftplib.FTP_TLS", autospec=True)
-    def test_ftp_load_from_directory_does_not_create_dirs_from_storage_URI_if_present(
-            self, mock_ftp_class):
-        mock_ftp = mock_ftp_class.return_value
-
-        mock_ftp.retrlines.side_effect = create_mock_ftp_directory_listing([
-            "drwxrwxr-x 3 test test 4.0K Apr  9 10:54 some",
-            "drwxrwxr-x 3 test test 4.0K Apr  9 10:54 dir",
-        ])
-
-        storage = storagelib.get_storage("ftps://user:password@ftp.foo.com/some/dir/file")
-
-        # empty folder
-        storage.load_from_directory(tempfile.mkdtemp())
-
-        mock_ftp_class.assert_called_with()
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
-        mock_ftp.prot_p.assert_called_with()
-        self.assertEqual(1, mock_ftp.mkd.call_count)
-        mock_ftp.mkd.assert_has_calls([mock.call("file")])
-        mock_ftp.cwd.assert_has_calls([
-            mock.call("some"),
-            mock.call("dir"),
-            mock.call("file")
-        ])
-
-    @mock.patch("ftplib.FTP_TLS", autospec=True)
-    def test_ftp_load_from_directory_create_dirs_from_load_directory(
-            self, mock_ftp_class):
-        mock_ftp = mock_ftp_class.return_value
-        mock_ftp.pwd.return_value = "pwd_return_value"
-        temp_directory = create_temp_nested_directory_with_files()
-
-        directory_listings = [
-            "drwxrwxr-x 3 test test 4.0K Apr  9 10:54 some",
-            "drwxrwxr-x 3 test test 4.0K Apr  9 10:54 dir",
-        ]
-
-        def get_directory_listing(_, callback):
-            if len(directory_listings):
-                return callback(directory_listings.pop(0))
-
-        mock_ftp.retrlines.side_effect = get_directory_listing
-
-        storage = storagelib.get_storage("ftps://user:password@ftp.foo.com/some/dir")
-
-        # empty folder
-        storage.load_from_directory(temp_directory["temp_directory"]["path"])
-
-        mock_ftp_class.assert_called_with()
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
-        mock_ftp.prot_p.assert_called_with()
-
-        mock_ftp.mkd.assert_has_calls([
-            mock.call(temp_directory["nested_temp_directory"]["name"])
-        ])
-
-        mock_ftp.cwd.assert_has_calls([
-            mock.call("some"),
-            mock.call("dir"),
-            mock.call("/some/dir"),
-            mock.call(temp_directory["nested_temp_directory"]["name"]),
-            mock.call("pwd_return_value"),
-            mock.call("/some/dir/" + temp_directory["nested_temp_directory"]["name"])
-        ])
-
-    @mock.patch("ftplib.FTP_TLS", autospec=True)
-    def test_ftp_load_from_directory_does_not_create_existing_dirs_from_load_directory(
-            self, mock_ftp_class):
-        mock_ftp = mock_ftp_class.return_value
-        mock_ftp.pwd.return_value = "pwd_return_value"
-        temp_directory = create_temp_nested_directory_with_files()
-
-        directory_listings = [
-            "drwxrwxr-x 3 test test 4.0K Apr  9 10:54 some",
-            "drwxrwxr-x 3 test test 4.0K Apr  9 10:54 dir",
-            "drwxrwxr-x 3 test test 4.0K Apr  9 10:54 {0}".format(
-                temp_directory["nested_temp_directory"]["name"]),
-        ]
-
-        def get_directory_listing(_, callback):
-            if len(directory_listings):
-                return callback(directory_listings.pop(0))
-
-        mock_ftp.retrlines.side_effect = get_directory_listing
-
-        storage = storagelib.get_storage("ftps://user:password@ftp.foo.com/some/dir")
-
-        # empty folder
-        storage.load_from_directory(temp_directory["temp_directory"]["path"])
-
-        mock_ftp_class.assert_called_with()
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
-        mock_ftp.prot_p.assert_called_with()
-        mock_ftp.mkd.assert_not_called()
-
-        mock_ftp.cwd.assert_has_calls([
-            mock.call("some"),
-            mock.call("dir"),
-            mock.call("/some/dir"),
-            mock.call(temp_directory["nested_temp_directory"]["name"]),
-            mock.call("pwd_return_value"),
-            mock.call("/some/dir/" + temp_directory["nested_temp_directory"]["name"])
-        ])
-
-    @mock.patch("__builtin__.open", autospec=True)
-    @mock.patch("ftplib.FTP_TLS", autospec=True)
-    def test_ftp_load_from_directory_creates_files_from_local_source_directory(
-            self, mock_ftp_class, mock_open):
-        mock_ftp = mock_ftp_class.return_value
-        mock_ftp.pwd.return_value = "pwd_return_value"
-        mock_open_return = mock_open.return_value.__enter__.return_value
-
-        temp_directory = create_temp_nested_directory_with_files()
-
-        directory_listings = [
-            "drwxrwxr-x 3 test test 4.0K Apr  9 10:54 {0}".format(
-                temp_directory["nested_temp_directory"]["name"]),
-        ]
-
-        def get_directory_listing(_, callback):
-            if len(directory_listings):
-                return callback(directory_listings.pop(0))
-
-        mock_ftp.retrlines.side_effect = get_directory_listing
-
-        storage = storagelib.get_storage("ftps://user:password@ftp.foo.com/dir")
-
-        # empty folder
-        storage.load_from_directory(temp_directory["temp_directory"]["path"])
-
-        mock_ftp_class.assert_called_with()
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
-        mock_ftp.prot_p.assert_called_with()
-
-        mock_ftp.storbinary.assert_has_calls([
-            mock.call(
-                "STOR {0}".format(temp_directory["temp_input_one"]["name"]), mock_open_return),
-            mock.call(
-                "STOR {0}".format(temp_directory["temp_input_two"]["name"]), mock_open_return),
-            mock.call(
-                "STOR {0}".format(temp_directory["nested_temp_input"]["name"]), mock_open_return)
-        ], any_order=True)
-
-        mock_ftp.cwd.assert_has_calls([
-            mock.call("dir"),
-            mock.call("/dir"),
-            mock.call(temp_directory["nested_temp_directory"]["name"]),
-            mock.call("pwd_return_value"),
-            mock.call("/dir/" + temp_directory["nested_temp_directory"]["name"])
-        ])
-
-    @mock.patch("ftplib.FTP_TLS", autospec=True)
-    def test_delete(self, mock_ftp_class):
-        mock_ftp = mock_ftp_class.return_value
-
-        storage = storagelib.get_storage("ftps://user:password@ftp.foo.com/some/dir/file")
-        storage.delete()
-
-        mock_ftp_class.assert_called_with()
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
-        mock_ftp.prot_p.assert_called_with()
-
-        mock_ftp.cwd.assert_called_with("some/dir")
-        mock_ftp.delete.assert_called_with("file")
-
-    @mock.patch("ftplib.FTP_TLS", autospec=True)
-    def test_delete_recursive(self, mock_ftp_class):
-        mock_ftp = mock_ftp_class.return_value
-
-        mock_ftp.pwd.return_value = "some/dir/file"
-
-        mock_ftp.retrlines.side_effect = create_mock_ftp_directory_listing([
-            # root
-            [
-                "drwxrwxr-x 3 test test 4.0K Apr  9 10:54 dir1",
-                "drwxrwxr-x 3 test test 4.0K Apr  9 10:54 dir2",
-                "-rwxrwxr-x 3 test test 4.0K Apr  9 10:54 file1",
-                "-rwxrwxr-x 3 test test 4.0K Apr  9 10:54 file2",
-            ],
-            # dir1
-            [
-                "drwxrwxr-x 3 test test 4.0K Apr  9 10:54 dir with spaces",
-                "-rwxrwxr-x 3 test test 4.0K Apr  9 10:54 file3",
-            ],
-            # dir with spaces
-            [
-                "-rwxrwxr-x 3 test test 4.0K Apr  9 10:54 file with spaces"
-            ],
-            # dir2
-            [
-                "drwxrwxr-x 3 test test 4.0K Apr  9 10:54 dir4",
-            ],
-        ])
-
-        storage = storagelib.get_storage("ftps://user:password@ftp.foo.com/some/dir/file")
-        storage.delete(recursive=True)
-
-        mock_ftp_class.assert_called_with()
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
-
-        mock_ftp.cwd.assert_has_calls([
-            mock.call("/some/dir/file"),
-            mock.call("some/dir/file/dir1"),
-            mock.call("some/dir/file/dir1/dir with spaces"),
-            mock.call("some/dir/file/dir2"),
-            mock.call("some/dir/file/dir2/dir4")
-        ])
-        self.assertEqual(5, mock_ftp.cwd.call_count)
-
-        mock_ftp.delete.assert_has_calls([
-            mock.call("/some/dir/file/dir1/dir with spaces/file with spaces"),
-            mock.call("/some/dir/file/dir1/file3"),
-            mock.call("/some/dir/file/file2"),
-            mock.call("/some/dir/file/file1")
-        ], any_order=True)
-        self.assertEqual(4, mock_ftp.delete.call_count)
-
-        mock_ftp.rmd.assert_has_calls([
-            mock.call("/some/dir/file/dir2/dir4"),
-            mock.call("/some/dir/file/dir2"),
-            mock.call("/some/dir/file/dir1/dir with spaces"),
-            mock.call("/some/dir/file/dir1"),
-            mock.call("/some/dir/file")
-        ])
-        self.assertEqual(5, mock_ftp.rmd.call_count)
 
 
 class TestS3Storage(TestCase):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -114,6 +114,7 @@ class TestLocalStorage(TestCase):
 
     def test_local_storage_save_to_directory(self):
         temp_directory = create_temp_nested_directory_with_files()
+
         storage = storagelib.get_storage(
             "file://{0}".format(temp_directory["temp_directory"]["path"]))
 
@@ -188,14 +189,12 @@ class TestLocalStorage(TestCase):
         mock_makedirs.assert_called_with("/foo/bar")
         mock_copy.assert_called_with("input_file", "/foo/bar/file")
 
-    @mock.patch("shutil.rmtree", autospec=True)
     @mock.patch("os.remove", autospec=True)
-    def test_local_storage_delete(self, mock_remove, mock_rmtree):
+    def test_local_storage_delete(self, mock_remove):
         storage = storagelib.get_storage("file:///folder/file")
         storage.delete()
 
         mock_remove.assert_called_with("/folder/file")
-        self.assertFalse(mock_rmtree.called)
 
     @mock.patch("shutil.rmtree", autospec=True)
     @mock.patch("os.remove", autospec=True)


### PR DESCRIPTION
@ustudio/dev please review

Updated storage library to (v0.7.3) support deleting directories loaded by `load_from_directory()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ustudio/storage/32)
<!-- Reviewable:end -->
