### PR TITLE
Enable ftp timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install via pip:
 pip install object_storage
 ```
 
-The current version is `0.7.3`.
+The current version is `0.8.0`.
 
 ## Quick Start ##
 
@@ -244,6 +244,11 @@ ftp://username:password@my-ftp-server/directory/awesome-file.txt[?download_url_b
 
 ```
 
+*NOTE* The FTP connection will have a default 60 second timeout on
+ network operations, which can be set by changing
+ `storage.storage.DEFAULT_FTP_TIMEOUT`, specified in seconds. The
+ timeout is per data chunk, not for transfer of the entire object.
+
 #### ftps ####
 
 A reference to a file on an FTP server, served using the FTPS
@@ -254,6 +259,9 @@ Example:
 ```
 ftps://username:password@my-secure-ftp-server/directory/awesome-file.txt[?download_url_base=<ENCODED-URL>]
 ```
+
+*NOTE* The FTP_TLS connection will have a default timeout specified in
+ the same manner as the `ftp` protocol (see above).
 
 ### retry ###
 

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,8 @@ dependencies:
   pre:
     - pip install -e .
     - pip install coverage
+  override:
+    - pip install -r requirements.txt
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,7 @@
 dependencies:
   pre:
-    - pip install --upgrade --upgrade-strategy eager pip
+    - pip --version
+    - pip install --upgrade --force-reinstall eager pip
     - pip install -e .
     - pip install coverage
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 dependencies:
   pre:
-    - pip install --upgrade pip
+    - pip install --upgrade --upgrade-strategy eager pip
     - pip install -e .
     - pip install coverage
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,7 @@ dependencies:
   pre:
     - pip install coverage
   override:
+    - pip install -r pyrax-requirements.txt
     - pip install -e .
     - pip install -r requirements.txt
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,9 @@
 dependencies:
   pre:
     - pip install coverage
+  override:
+    - pip install -e .
+    - pip install -r requirements.txt
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -1,11 +1,6 @@
 dependencies:
   pre:
-    - pip --version
-    - pip install --upgrade --force-reinstall eager pip
-    - pip install -e .
     - pip install coverage
-  override:
-    - pip install -r requirements.txt
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,6 @@
 dependencies:
   pre:
+    - pip install --upgrade pip
     - pip install -e .
     - pip install coverage
   override:

--- a/pyrax-requirements.txt
+++ b/pyrax-requirements.txt
@@ -1,3 +1,4 @@
+pbr==1.10.0
 python-keystoneclient==1.8.1
 oslo.i18n==2.7.0
 oslo.serialization==1.11.0

--- a/pyrax-requirements.txt
+++ b/pyrax-requirements.txt
@@ -1,0 +1,6 @@
+python-keystoneclient==1.8.1
+oslo.i18n==2.7.0
+oslo.serialization==1.11.0
+oslo.utils==2.8.0
+debtcollector==1.11.0
+stevedore==1.20.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
 ]
 
 setup(name="object_storage",
-      version="0.7.3",
+      version="0.8.0",
       description="Python library for accessing files over various file transfer protocols.",
       url="https://github.com/ustudio/storage",
       packages=["storage"],

--- a/storage/storage.py
+++ b/storage/storage.py
@@ -400,6 +400,10 @@ class CloudFilesStorage(SwiftStorage):
         self._cloudfiles = context.get_client("cloudfiles", region, public=public)
 
 
+"""Socket timeout (float seconds) for FTP transfers."""
+DEFAULT_FTP_TIMEOUT = 60.0
+
+
 @register_storage_protocol("ftp")
 class FTPStorage(Storage):
     """FTP storage.
@@ -425,7 +429,7 @@ class FTPStorage(Storage):
         self._download_url_base = query.get("download_url_base", [None])[0]
 
     def _connect(self):
-        ftp_client = ftplib.FTP()
+        ftp_client = ftplib.FTP(timeout=DEFAULT_FTP_TIMEOUT)
         ftp_client.connect(self._hostname, port=self._port)
         ftp_client.login(self._username, self._password)
 
@@ -600,7 +604,7 @@ class FTPStorage(Storage):
 @register_storage_protocol("ftps")
 class FTPSStorage(FTPStorage):
     def _connect(self):
-        ftp_client = ftplib.FTP_TLS()
+        ftp_client = ftplib.FTP_TLS(timeout=DEFAULT_FTP_TIMEOUT)
         ftp_client.connect(self._hostname, port=self._port)
         ftp_client.login(self._username, self._password)
         ftp_client.prot_p()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -898,7 +898,7 @@ class TestFTPStorage(TestCase):
 
         storage.save_to_filename(temp_output.name)
 
-        mock_ftp_class.assert_called_with()
+        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
         mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
         mock_ftp.login.assert_called_with("user", "password")
 
@@ -928,7 +928,7 @@ class TestFTPStorage(TestCase):
 
         storage.save_to_file(out_file)
 
-        mock_ftp_class.assert_called_with()
+        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
         mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
         mock_ftp.login.assert_called_with("user", "password")
 
@@ -957,7 +957,7 @@ class TestFTPStorage(TestCase):
 
         storage.save_to_file(out_file)
 
-        mock_ftp_class.assert_called_with()
+        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
         mock_ftp.connect.assert_called_with("ftp.foo.com", port=12345)
         mock_ftp.login.assert_called_with("user", "password")
 
@@ -985,7 +985,7 @@ class TestFTPStorage(TestCase):
 
         storage.save_to_directory("/cat/pants")
 
-        mock_ftp_class.assert_called_with()
+        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
         mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
         mock_ftp.login.assert_called_with("user", "password")
 
@@ -1047,7 +1047,7 @@ class TestFTPStorage(TestCase):
 
         storage.save_to_directory("/cat/pants")
 
-        mock_ftp_class.assert_called_with()
+        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
         mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
         mock_ftp.login.assert_called_with("user", "password")
 
@@ -1095,7 +1095,7 @@ class TestFTPStorage(TestCase):
 
         storage.load_from_filename("some_file")
 
-        mock_ftp_class.assert_called_with()
+        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
         mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
         mock_ftp.login.assert_called_with("user", "password")
 
@@ -1114,7 +1114,7 @@ class TestFTPStorage(TestCase):
 
         storage.load_from_filename("some_file")
 
-        mock_ftp_class.assert_called_with()
+        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
         mock_ftp.connect.assert_called_with("ftp.foo.com", port=12345)
         mock_ftp.login.assert_called_with("user", "password")
 
@@ -1133,7 +1133,7 @@ class TestFTPStorage(TestCase):
 
         storage.load_from_file(in_file)
 
-        mock_ftp_class.assert_called_with()
+        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
         mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
         mock_ftp.login.assert_called_with("user", "password")
 
@@ -1153,7 +1153,7 @@ class TestFTPStorage(TestCase):
         # empty folder
         storage.load_from_directory(tempfile.mkdtemp())
 
-        mock_ftp_class.assert_called_with()
+        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
         mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
         mock_ftp.login.assert_called_with("user", "password")
 
@@ -1178,7 +1178,7 @@ class TestFTPStorage(TestCase):
         # empty folder
         storage.load_from_directory(tempfile.mkdtemp())
 
-        mock_ftp_class.assert_called_with()
+        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
         mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
         mock_ftp.login.assert_called_with("user", "password")
         self.assertEqual(1, mock_ftp.mkd.call_count)
@@ -1212,7 +1212,7 @@ class TestFTPStorage(TestCase):
         # empty folder
         storage.load_from_directory(temp_directory["temp_directory"]["path"])
 
-        mock_ftp_class.assert_called_with()
+        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
         mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
         mock_ftp.login.assert_called_with("user", "password")
 
@@ -1254,7 +1254,7 @@ class TestFTPStorage(TestCase):
         # empty folder
         storage.load_from_directory(temp_directory["temp_directory"]["path"])
 
-        mock_ftp_class.assert_called_with()
+        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
         mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
         mock_ftp.login.assert_called_with("user", "password")
         mock_ftp.mkd.assert_not_called()
@@ -1294,7 +1294,7 @@ class TestFTPStorage(TestCase):
         # empty folder
         storage.load_from_directory(temp_directory["temp_directory"]["path"])
 
-        mock_ftp_class.assert_called_with()
+        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
         mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
         mock_ftp.login.assert_called_with("user", "password")
 
@@ -1322,7 +1322,7 @@ class TestFTPStorage(TestCase):
         storage = storagelib.get_storage("ftp://user:password@ftp.foo.com/some/dir/file")
         storage.delete()
 
-        mock_ftp_class.assert_called_with()
+        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
         mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
         mock_ftp.login.assert_called_with("user", "password")
 
@@ -1361,7 +1361,7 @@ class TestFTPStorage(TestCase):
         storage = storagelib.get_storage("ftp://user:password@ftp.foo.com/some/dir/file")
         storage.delete_directory()
 
-        mock_ftp_class.assert_called_with()
+        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
         mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
         mock_ftp.login.assert_called_with("user", "password")
 
@@ -1418,7 +1418,7 @@ class TestFTPStorage(TestCase):
 
 class TestFTPSStorage(TestCase):
     @mock.patch("ftplib.FTP_TLS", autospec=True)
-    def test_ftps_scheme_connects_using_ftp_lts_class(self, mock_ftp_lts_class):
+    def test_ftps_scheme_connects_using_ftp_tls_class(self, mock_ftp_tls_class):
         temp_output = tempfile.NamedTemporaryFile()
 
         mock_results = ["foo", "bar"]
@@ -1429,14 +1429,14 @@ class TestFTPSStorage(TestCase):
 
             return "226"
 
-        mock_ftp = mock_ftp_lts_class.return_value
+        mock_ftp = mock_ftp_tls_class.return_value
         mock_ftp.retrbinary.side_effect = mock_retrbinary
 
         storage = storagelib.get_storage("ftps://user:password@ftp.foo.com/some/dir/file")
 
         storage.save_to_filename(temp_output.name)
 
-        mock_ftp_lts_class.assert_called_with()
+        mock_ftp_tls_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
         mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
         mock_ftp.login.assert_called_with("user", "password")
         mock_ftp.prot_p.assert_called_with()


### PR DESCRIPTION
This adds support for a default FTP timeout, so FTP transfers don't hang forever, as we have seen recently.

Note, there are still some weird dependency issues in CI that might need to get fixed, but I'd like to get the review of at least the code started.

@ustudio/dev Please review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ustudio/storage/34)
<!-- Reviewable:end -->
