### PR TITLE
Use threads instead of signals to implement timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install via pip:
 pip install object_storage
 ```
 
-The current version is `0.9.0`.
+The current version is `0.9.1`.
 
 ## Quick Start ##
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
 ]
 
 setup(name="object_storage",
-      version="0.9.0",
+      version="0.9.1",
       description="Python library for accessing files over various file transfer protocols.",
       url="https://github.com/ustudio/storage",
       packages=["storage"],


### PR DESCRIPTION
Switched to using threads for CloudFiles/Swift authentication timeouts, so the storage library can be used from inside threads.

@ustudio/dev Please review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ustudio/storage/37)
<!-- Reviewable:end -->
