### PR TITLE
Retry individual file failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install via pip:
 pip install object_storage
 ```
 
-The current version is `0.9.1`.
+The current version is `0.10.0`.
 
 ## Quick Start ##
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
 ]
 
 setup(name="object_storage",
-      version="0.9.1",
+      version="0.10.0",
       description="Python library for accessing files over various file transfer protocols.",
       url="https://github.com/ustudio/storage",
       packages=["storage"],

--- a/storage/storage.py
+++ b/storage/storage.py
@@ -329,7 +329,12 @@ class SwiftStorage(Storage):
             if not os.path.exists(directory):
                 os.makedirs(directory)
 
-            self._cloudfiles.download_object(container_name, file, directory, structure=False)
+            retry.attempt(
+                self._cloudfiles.download_object,
+                container_name,
+                file,
+                directory,
+                structure=False)
 
     def _upload_file(self, file_or_path, object_path=None):
         self._authenticate()
@@ -707,8 +712,11 @@ class S3Storage(Storage):
                 if not os.path.exists(directory_path + file_path):
                     os.makedirs(directory_path + file_path)
 
-                client.download_file(
-                    self._bucket, file["Key"], directory_path + file_key)
+                retry.attempt(
+                    client.download_file,
+                    self._bucket,
+                    file["Key"],
+                    directory_path + file_key)
 
     def load_from_filename(self, file_path):
         client = self._connect()

--- a/storage/storage.py
+++ b/storage/storage.py
@@ -9,6 +9,7 @@ import os.path
 import pyrax
 import Queue
 import re
+import retry
 import shutil
 import threading
 import urllib
@@ -356,8 +357,10 @@ class SwiftStorage(Storage):
             container_path = root.replace(source_directory, object_name, 1)
 
             for file in files:
-                self._upload_file(
-                    os.path.join(root, file), object_path=os.path.join(container_path, file))
+                retry.attempt(
+                    self._upload_file,
+                    os.path.join(root, file),
+                    object_path=os.path.join(container_path, file))
 
     def delete(self):
         self._authenticate()
@@ -726,7 +729,11 @@ class S3Storage(Storage):
 
             for file in files:
                 upload_path = os.path.join(relative_path, file)
-                client.upload_file(os.path.join(root, file), self._bucket, upload_path)
+                retry.attempt(
+                    client.upload_file,
+                    os.path.join(root, file),
+                    self._bucket,
+                    upload_path)
 
     def delete(self):
         client = self._connect()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -557,6 +557,122 @@ class TestSwiftStorage(TestCase):
         mock_swift.download_object.assert_any_call(
             self.params["container"], expected_mp4, "/tmp/cat/pants/a/b/c", structure=False)
 
+    @mock.patch("storage.retry.time.sleep", autospec=True)
+    @mock.patch("storage.retry.random.uniform", autospec=True)
+    @mock.patch("os.path.exists", return_value=False)
+    @mock.patch("os.makedirs")
+    @mock.patch("pyrax.create_context")
+    @mock.patch("storage.storage.timeout", wraps=storagelib.storage.timeout)
+    def test_swift_save_to_directory_retries_failed_file_downloads(
+            self, mock_timeout, mock_create_context, mock_makedirs, mock_path_exists, mock_uniform,
+            mock_sleep):
+
+        expected_jpg = self.RackspaceObject("file/a/0.jpg", "image/jpg")
+        expected_mp4 = self.RackspaceObject("file/a/b/c/1.mp4", "video/mp4")
+
+        expected_files = [
+            expected_jpg,
+            expected_mp4
+        ]
+        mock_context = mock_create_context.return_value
+        mock_swift = mock_context.get_client.return_value
+
+        mock_swift.list_container_objects.return_value = expected_files
+
+        mock_swift.download_object.side_effect = [
+            None,
+            storagelib.storage.TimeoutError,
+            None
+        ]
+
+        uri = "swift://{username}:{password}@{container}/{file}?" \
+              "auth_endpoint={auth_endpoint}&region={region}" \
+              "&tenant_id={tenant_id}".format(**self.params)
+
+        storagelib.get_storage(uri).save_to_directory("/tmp/cat/pants")
+
+        self._assert_default_login_correct(mock_create_context, mock_timeout)
+        mock_swift.list_container_objects.assert_called_with(
+            self.params["container"], prefix=self.params["file"])
+
+        mock_makedirs.assert_has_calls([
+            mock.call("/tmp/cat/pants/a"), mock.call("/tmp/cat/pants/a/b/c")])
+
+        self.assertEqual(3, mock_swift.download_object.call_count)
+        mock_swift.download_object.assert_has_calls([
+            mock.call(self.params["container"], expected_jpg, "/tmp/cat/pants/a", structure=False),
+            mock.call(
+                self.params["container"], expected_mp4, "/tmp/cat/pants/a/b/c", structure=False),
+            mock.call(
+                self.params["container"], expected_mp4, "/tmp/cat/pants/a/b/c", structure=False)
+        ])
+
+        mock_uniform.assert_called_once_with(0, 1)
+
+        mock_sleep.assert_called_once_with(mock_uniform.return_value)
+
+    @mock.patch("storage.retry.time.sleep", autospec=True)
+    @mock.patch("storage.retry.random.uniform", autospec=True)
+    @mock.patch("os.path.exists", return_value=False)
+    @mock.patch("os.makedirs")
+    @mock.patch("pyrax.create_context")
+    @mock.patch("storage.storage.timeout", wraps=storagelib.storage.timeout)
+    def test_swift_save_to_directory_fails_after_five_failed_file_download_retries(
+            self, mock_timeout, mock_create_context, mock_makedirs, mock_path_exists, mock_uniform,
+            mock_sleep):
+
+        expected_jpg = self.RackspaceObject("file/a/0.jpg", "image/jpg")
+        expected_mp4 = self.RackspaceObject("file/a/b/c/1.mp4", "video/mp4")
+
+        expected_files = [
+            expected_jpg,
+            expected_mp4
+        ]
+        mock_context = mock_create_context.return_value
+        mock_swift = mock_context.get_client.return_value
+
+        mock_swift.list_container_objects.return_value = expected_files
+
+        mock_swift.download_object.side_effect = [
+            storagelib.storage.TimeoutError,
+            IOError,
+            IOError,
+            IOError,
+            RuntimeError,
+        ]
+
+        uri = "swift://{username}:{password}@{container}/{file}?" \
+              "auth_endpoint={auth_endpoint}&region={region}" \
+              "&tenant_id={tenant_id}".format(**self.params)
+
+        with self.assertRaises(RuntimeError):
+            storagelib.get_storage(uri).save_to_directory("/tmp/cat/pants")
+
+        self._assert_default_login_correct(mock_create_context, mock_timeout)
+        mock_swift.list_container_objects.assert_called_with(
+            self.params["container"], prefix=self.params["file"])
+
+        mock_makedirs.assert_called_once_with("/tmp/cat/pants/a")
+
+        self.assertEqual(5, mock_swift.download_object.call_count)
+        mock_swift.download_object.assert_has_calls([
+            mock.call(self.params["container"], expected_jpg, "/tmp/cat/pants/a", structure=False),
+            mock.call(self.params["container"], expected_jpg, "/tmp/cat/pants/a", structure=False),
+            mock.call(self.params["container"], expected_jpg, "/tmp/cat/pants/a", structure=False),
+            mock.call(self.params["container"], expected_jpg, "/tmp/cat/pants/a", structure=False),
+            mock.call(self.params["container"], expected_jpg, "/tmp/cat/pants/a", structure=False)
+        ])
+
+        mock_uniform.assert_has_calls([
+            mock.call(0, 1),
+            mock.call(0, 3),
+            mock.call(0, 7),
+            mock.call(0, 15)
+        ])
+
+        self.assertEqual(4, mock_sleep.call_count)
+        mock_sleep.assert_called_with(mock_uniform.return_value)
+
     @mock.patch("os.path.exists", return_value=False)
     @mock.patch("os.makedirs")
     @mock.patch("pyrax.create_context")
@@ -1791,6 +1907,180 @@ class TestS3Storage(TestCase):
             mock.call("bucket", "directory/e.txt", "save_to_directory/e.txt"),
             mock.call("bucket", "directory/e/f/d.txt", "save_to_directory/e/f/d.txt"),
             mock.call("bucket", "directory/g.txt", "save_to_directory/g.txt")])
+
+    @mock.patch("storage.retry.time.sleep", autospec=True)
+    @mock.patch("storage.retry.random.uniform", autospec=True)
+    @mock.patch("os.makedirs")
+    @mock.patch("os.path.exists")
+    @mock.patch("boto3.s3.transfer.S3Transfer", autospec=True)
+    @mock.patch("boto3.session.Session", autospec=True)
+    def test_save_to_directory_retries_failed_file_uploads(
+            self, mock_session_class, mock_transfer_class, mock_path_exists, mock_makedirs,
+            mock_uniform, mock_sleep):
+        mock_session = mock_session_class.return_value
+        mock_s3_client = mock_session.client.return_value
+        mock_s3_client.list_objects.return_value = {
+            "Contents": [
+                {
+                    "Key": "directory/"
+                },
+                {
+                    "Key": "directory/b/"
+                },
+                {
+                    "Key": "directory/b/c.txt"
+                },
+                {
+                    "Key": "directory/e.txt"
+                },
+                {
+                    "Key": "directory/e/f/d.txt"
+                },
+                {
+                    "Key": ""
+                },
+                {
+                    "Key": "directory/g.txt"
+                }
+            ]
+        }
+
+        mock_path_exists.return_value = False
+        path_mock_path_exists_calls = []
+
+        def mock_path_exists_side_effect(path):
+            if any(path in x for x in path_mock_path_exists_calls):
+                return True
+            else:
+                path_mock_path_exists_calls.append(path)
+                return False
+
+        mock_path_exists.side_effect = mock_path_exists_side_effect
+
+        mock_s3_client.download_file.side_effect = [
+            None,
+            IOError,
+            None,
+            None,
+            None
+        ]
+
+        storage = storagelib.get_storage(
+            "s3://access_key:access_secret@bucket/directory?region=US_EAST")
+
+        storage.save_to_directory("save_to_directory")
+
+        mock_session_class.assert_called_with(
+            aws_access_key_id="access_key",
+            aws_secret_access_key="access_secret",
+            region_name="US_EAST")
+
+        mock_s3_client.list_objects.assert_called_with(Bucket="bucket", Prefix="directory/")
+        mock_makedirs.assert_has_calls(
+            [mock.call("save_to_directory/b"), mock.call("save_to_directory/e/f")])
+        mock_session.client.assert_called_with("s3")
+
+        self.assertEqual(5, mock_s3_client.download_file.call_count)
+        mock_s3_client.download_file.assert_has_calls([
+            mock.call("bucket", "directory/b/c.txt", "save_to_directory/b/c.txt"),
+            mock.call("bucket", "directory/e.txt", "save_to_directory/e.txt"),
+            mock.call("bucket", "directory/e.txt", "save_to_directory/e.txt"),
+            mock.call("bucket", "directory/e/f/d.txt", "save_to_directory/e/f/d.txt"),
+            mock.call("bucket", "directory/g.txt", "save_to_directory/g.txt")])
+
+        mock_uniform.assert_called_once_with(0, 1)
+
+        mock_sleep.assert_called_once_with(mock_uniform.return_value)
+
+    @mock.patch("storage.retry.time.sleep", autospec=True)
+    @mock.patch("storage.retry.random.uniform", autospec=True)
+    @mock.patch("os.makedirs")
+    @mock.patch("os.path.exists")
+    @mock.patch("boto3.s3.transfer.S3Transfer", autospec=True)
+    @mock.patch("boto3.session.Session", autospec=True)
+    def test_save_to_directory_fails_after_five_failed_file_download_retries(
+            self, mock_session_class, mock_transfer_class, mock_path_exists, mock_makedirs,
+            mock_uniform, mock_sleep):
+        mock_session = mock_session_class.return_value
+        mock_s3_client = mock_session.client.return_value
+        mock_s3_client.list_objects.return_value = {
+            "Contents": [
+                {
+                    "Key": "directory/"
+                },
+                {
+                    "Key": "directory/b/"
+                },
+                {
+                    "Key": "directory/b/c.txt"
+                },
+                {
+                    "Key": "directory/e.txt"
+                },
+                {
+                    "Key": "directory/e/f/d.txt"
+                },
+                {
+                    "Key": ""
+                },
+                {
+                    "Key": "directory/g.txt"
+                }
+            ]
+        }
+
+        mock_path_exists.return_value = False
+        path_mock_path_exists_calls = []
+
+        def mock_path_exists_side_effect(path):
+            if any(path in x for x in path_mock_path_exists_calls):
+                return True
+            else:
+                path_mock_path_exists_calls.append(path)
+                return False
+
+        mock_path_exists.side_effect = mock_path_exists_side_effect
+
+        mock_s3_client.download_file.side_effect = [
+            RuntimeError,
+            RuntimeError,
+            RuntimeError,
+            RuntimeError,
+            IOError,
+        ]
+
+        storage = storagelib.get_storage(
+            "s3://access_key:access_secret@bucket/directory?region=US_EAST")
+
+        with self.assertRaises(IOError):
+            storage.save_to_directory("save_to_directory")
+
+        mock_session_class.assert_called_with(
+            aws_access_key_id="access_key",
+            aws_secret_access_key="access_secret",
+            region_name="US_EAST")
+
+        mock_s3_client.list_objects.assert_called_with(Bucket="bucket", Prefix="directory/")
+        mock_makedirs.assert_called_once_with("save_to_directory/b")
+        mock_session.client.assert_called_with("s3")
+
+        self.assertEqual(5, mock_s3_client.download_file.call_count)
+        mock_s3_client.download_file.assert_has_calls([
+            mock.call("bucket", "directory/b/c.txt", "save_to_directory/b/c.txt"),
+            mock.call("bucket", "directory/b/c.txt", "save_to_directory/b/c.txt"),
+            mock.call("bucket", "directory/b/c.txt", "save_to_directory/b/c.txt"),
+            mock.call("bucket", "directory/b/c.txt", "save_to_directory/b/c.txt"),
+            mock.call("bucket", "directory/b/c.txt", "save_to_directory/b/c.txt")])
+
+        mock_uniform.assert_has_calls([
+            mock.call(0, 1),
+            mock.call(0, 3),
+            mock.call(0, 7),
+            mock.call(0, 15)
+        ])
+
+        self.assertEqual(4, mock_sleep.call_count)
+        mock_sleep.assert_called_with(mock_uniform.return_value)
 
     @mock.patch("boto3.s3.transfer.S3Transfer", autospec=True)
     @mock.patch("boto3.session.Session", autospec=True)


### PR DESCRIPTION
Calls to `load_from_directory` and `save_to_directory` have been encountering an increased number of failures recently when the directories being transferred contain a large number of files. I have added retries to the individual file uploads/downloads for the Swift, Cloudfiles, and S3 storage classes to try to reduce the impact of these failures.

Note that I did *not* add retry logic to the methods on the `FTPStorage` class as this would require a more significant change to the library, and because`load_from_directory` and `save_to_directory` are less frequently used with FTP.

@ustudio/dev Please review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ustudio/storage/38)
<!-- Reviewable:end -->
