### PR TITLE
Enable TCP Keepalive on FTP Command Sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install via pip:
 pip install object_storage
 ```
 
-The current version is `0.10.0`.
+The current version is `0.11.0`.
 
 ## Quick Start ##
 
@@ -259,6 +259,12 @@ ftp://username:password@my-ftp-server/directory/awesome-file.txt[?download_url_b
  `storage.storage.DEFAULT_FTP_TIMEOUT`, specified in seconds. The
  timeout is per data chunk, not for transfer of the entire object.
 
+**Note** The FTP connection's command socket will have TCP_KEEPALIVE
+  turned on by default, as configurable by
+  `storage.storage.DEFAULT_FTP_KEEPALIVE_ENABLE`, and will configure
+  TCP keepalive options when the platform supports them, using
+  similar configuration globals.
+
 #### ftps ####
 
 A reference to a file on an FTP server, served using the FTPS
@@ -270,8 +276,9 @@ Example:
 ftps://username:password@my-secure-ftp-server/directory/awesome-file.txt[?download_url_base=<ENCODED-URL>]
 ```
 
-**Note** The FTP_TLS connection will have a default timeout specified in
- the same manner as the `ftp` protocol (see above).
+**Note** The FTP_TLS connection will have a default timeout and TCP
+ keepalive specified in the same manner as the `ftp` protocol (see
+ above).
 
 ### retry ###
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,5 @@
 dependencies:
   pre:
-    - pip install pip==9.0.1
     - pip install coverage
   override:
     - pip install -r pyrax-requirements.txt

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,6 @@
 dependencies:
   pre:
+    - pip install pip==9.0.1
     - pip install coverage
   override:
     - pip install -r pyrax-requirements.txt

--- a/pyrax-requirements.txt
+++ b/pyrax-requirements.txt
@@ -1,6 +1,7 @@
 pbr==1.10.0
 python-keystoneclient==1.8.1
 oslo.i18n==2.7.0
+oslo.config==4.12.0
 oslo.serialization==1.11.0
 oslo.utils==2.8.0
 debtcollector==1.11.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
 ]
 
 setup(name="object_storage",
-      version="0.10.0",
+      version="0.11.0",
       description="Python library for accessing files over various file transfer protocols.",
       url="https://github.com/ustudio/storage",
       packages=["storage"],

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1159,6 +1159,11 @@ class TestRackspaceStorage(TestCase):
 
 
 class TestFTPStorage(TestCase):
+    def assert_connected(self, mock_ftp_class, mock_ftp, expected_port=21):
+        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
+        mock_ftp.connect.assert_called_with("ftp.foo.com", port=expected_port)
+        mock_ftp.login.assert_called_with("user", "password")
+
     @mock.patch("ftplib.FTP", autospec=True)
     def test_ftp_save_to_filename(self, mock_ftp_class):
         temp_output = tempfile.NamedTemporaryFile()
@@ -1178,9 +1183,7 @@ class TestFTPStorage(TestCase):
 
         storage.save_to_filename(temp_output.name)
 
-        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
+        self.assert_connected(mock_ftp_class, mock_ftp)
 
         mock_ftp.cwd.assert_called_with("some/dir")
         self.assertEqual(1, mock_ftp.retrbinary.call_count)
@@ -1208,9 +1211,7 @@ class TestFTPStorage(TestCase):
 
         storage.save_to_file(out_file)
 
-        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
+        self.assert_connected(mock_ftp_class, mock_ftp)
 
         mock_ftp.cwd.assert_called_with("some/dir")
         self.assertEqual(1, mock_ftp.retrbinary.call_count)
@@ -1237,9 +1238,7 @@ class TestFTPStorage(TestCase):
 
         storage.save_to_file(out_file)
 
-        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=12345)
-        mock_ftp.login.assert_called_with("user", "password")
+        self.assert_connected(mock_ftp_class, mock_ftp, 12345)
 
         mock_ftp.cwd.assert_called_with("some/dir")
         self.assertEqual(1, mock_ftp.retrbinary.call_count)
@@ -1265,9 +1264,7 @@ class TestFTPStorage(TestCase):
 
         storage.save_to_directory("/cat/pants")
 
-        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
+        self.assert_connected(mock_ftp_class, mock_ftp)
 
         mock_ftp.cwd.assert_has_calls([
             mock.call("/some/dir/file"),
@@ -1327,9 +1324,7 @@ class TestFTPStorage(TestCase):
 
         storage.save_to_directory("/cat/pants")
 
-        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
+        self.assert_connected(mock_ftp_class, mock_ftp)
 
         self.assertEqual(5, mock_ftp.cwd.call_count)
         mock_ftp.cwd.assert_has_calls([
@@ -1375,9 +1370,7 @@ class TestFTPStorage(TestCase):
 
         storage.load_from_filename("some_file")
 
-        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
+        self.assert_connected(mock_ftp_class, mock_ftp)
 
         mock_ftp.cwd.assert_called_with("some/dir")
 
@@ -1394,9 +1387,7 @@ class TestFTPStorage(TestCase):
 
         storage.load_from_filename("some_file")
 
-        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=12345)
-        mock_ftp.login.assert_called_with("user", "password")
+        self.assert_connected(mock_ftp_class, mock_ftp, 12345)
 
         mock_ftp.cwd.assert_called_with("some/dir")
 
@@ -1413,9 +1404,7 @@ class TestFTPStorage(TestCase):
 
         storage.load_from_file(in_file)
 
-        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
+        self.assert_connected(mock_ftp_class, mock_ftp)
 
         mock_ftp.cwd.assert_called_with("some/dir")
 
@@ -1433,9 +1422,7 @@ class TestFTPStorage(TestCase):
         # empty folder
         storage.load_from_directory(tempfile.mkdtemp())
 
-        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
+        self.assert_connected(mock_ftp_class, mock_ftp)
 
         mock_ftp.mkd.assert_has_calls([
             mock.call("some"),
@@ -1458,9 +1445,8 @@ class TestFTPStorage(TestCase):
         # empty folder
         storage.load_from_directory(tempfile.mkdtemp())
 
-        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
+        self.assert_connected(mock_ftp_class, mock_ftp)
+
         self.assertEqual(1, mock_ftp.mkd.call_count)
         mock_ftp.mkd.assert_has_calls([mock.call("file")])
         mock_ftp.cwd.assert_has_calls([
@@ -1492,9 +1478,7 @@ class TestFTPStorage(TestCase):
         # empty folder
         storage.load_from_directory(temp_directory["temp_directory"]["path"])
 
-        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
+        self.assert_connected(mock_ftp_class, mock_ftp)
 
         mock_ftp.mkd.assert_has_calls([
             mock.call(temp_directory["nested_temp_directory"]["name"])
@@ -1534,9 +1518,8 @@ class TestFTPStorage(TestCase):
         # empty folder
         storage.load_from_directory(temp_directory["temp_directory"]["path"])
 
-        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
+        self.assert_connected(mock_ftp_class, mock_ftp)
+
         mock_ftp.mkd.assert_not_called()
 
         mock_ftp.cwd.assert_has_calls([
@@ -1574,9 +1557,7 @@ class TestFTPStorage(TestCase):
         # empty folder
         storage.load_from_directory(temp_directory["temp_directory"]["path"])
 
-        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
+        self.assert_connected(mock_ftp_class, mock_ftp)
 
         mock_ftp.storbinary.assert_has_calls([
             mock.call(
@@ -1602,9 +1583,7 @@ class TestFTPStorage(TestCase):
         storage = storagelib.get_storage("ftp://user:password@ftp.foo.com/some/dir/file")
         storage.delete()
 
-        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
+        self.assert_connected(mock_ftp_class, mock_ftp)
 
         mock_ftp.cwd.assert_called_with("some/dir")
         mock_ftp.delete.assert_called_with("file")
@@ -1641,9 +1620,7 @@ class TestFTPStorage(TestCase):
         storage = storagelib.get_storage("ftp://user:password@ftp.foo.com/some/dir/file")
         storage.delete_directory()
 
-        mock_ftp_class.assert_called_with(timeout=storagelib.storage.DEFAULT_FTP_TIMEOUT)
-        mock_ftp.connect.assert_called_with("ftp.foo.com", port=21)
-        mock_ftp.login.assert_called_with("user", "password")
+        self.assert_connected(mock_ftp_class, mock_ftp)
 
         mock_ftp.cwd.assert_has_calls([
             mock.call("/some/dir/file"),


### PR DESCRIPTION
This enables TCP keepalive and the FTP command socket, to work around socket timeout issues in certain environments, when the transfer takes a long time, leaving the command socket idle.

@ustudio/reviewers Please review