### PR TITLE
Re-release 0.12.0 as 0.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install via pip:
 pip install object_storage
 ```
 
-The current version is `0.12.0`.
+The current version is `0.12.1`.
 
 ## Quick Start ##
 

--- a/pyrax-requirements.txt
+++ b/pyrax-requirements.txt
@@ -1,3 +1,4 @@
+keyring==18.0.1
 pbr==1.10.0
 python-keystoneclient==1.8.1
 oslo.i18n==2.7.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
 ]
 
 setup(name="object_storage",
-      version="0.12.0",
+      version="0.12.1",
       description="Python library for accessing files over various file transfer protocols.",
       url="https://github.com/ustudio/storage",
       packages=["storage"],


### PR DESCRIPTION
This just re-releases v0.12.0 with a new version number. After we released it, we thought there was an error that made it unusable, so we quickly deleted it from PyPI, to prevent any downstream projects from being affected. However, once we were able to debug the issue, it was discovered that it was not an issue with the storage library at all, so no changes needed to be made. However, we do need to bump the version, since 0.12.0 is "taken" at PyPI.

Also, while debugging, we discovered that the latest version of keyring stopped supporting Python2, so we need to force an older version when installing the dependencies for testing. (doesn't affect downstream projects).

@ustudio/reviewers Please review.