### PR TITLE
Correctly work around PyRax bug with newer requests library

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install via pip:
 pip install object_storage
 ```
 
-The current version is `0.12.2`.
+The current version is `0.12.3`.
 
 ## Quick Start ##
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
 ]
 
 setup(name="object_storage",
-      version="0.12.2",
+      version="0.12.3",
       description="Python library for accessing files over various file transfer protocols.",
       url="https://github.com/ustudio/storage",
       packages=["storage"],

--- a/storage/swift_storage.py
+++ b/storage/swift_storage.py
@@ -246,7 +246,7 @@ class CloudFilesStorage(SwiftStorage):
 
         if self.download_url_key is None:
             temp_url_keys = filter(
-                lambda (k, v): k.lower() == "temp_url_key",
+                lambda (k, v): k.lower().endswith("temp_url_key"),
                 self._cloudfiles.get_account_metadata().items())
 
             if len(temp_url_keys) > 0:

--- a/tests/test_swift_storage.py
+++ b/tests/test_swift_storage.py
@@ -859,7 +859,7 @@ class TestRackspaceStorage(TestCase):
 
     @mock.patch("pyrax.create_context")
     @mock.patch("storage.swift_storage.timeout", wraps=storagelib.swift_storage.timeout)
-    def test_rackspace_ignores_case_of_metadata_when_fetching_download_url_key(
+    def test_rackspace_handles_incorrectly_filtered_metadata_when_fetching_download_url_key(
             self, mock_timeout, mock_create_context):
         uri = "cloudfiles://{username}:{api_key}@{container}/{file}".format(
             username="username", api_key="apikey", container="container", file="file.txt")
@@ -868,7 +868,7 @@ class TestRackspaceStorage(TestCase):
 
         mock_cloudfiles.get_account_metadata.return_value = {
             "some_metadata": "values",
-            "Temp_Url_Key": "secret_key_from_server"
+            "X_Account_Meta_Temp_Url_Key": "secret_key_from_server"
         }
 
         storage = storagelib.get_storage(uri)


### PR DESCRIPTION
When `requests` returns headers without lowercasing them, `pyrax` correctly *finds* the headers that start with `X-Account-Meta`, but it doesn't correctly remove that prefix from the header before returning the dictionary of account metadata.

@ustudio/reviewers Please review