### PR TITLE
Fix Google delete_directory bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install via pip:
 pip install object_storage
 ```
 
-The current version is `0.12.4`.
+The current version is `0.12.5`.
 
 ## Quick Start ##
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
 ]
 
 setup(name="object_storage",
-      version="0.12.4",
+      version="0.12.5",
       description="Python library for accessing files over various file transfer protocols.",
       url="https://github.com/ustudio/storage",
       packages=["storage"],

--- a/storage/google_storage.py
+++ b/storage/google_storage.py
@@ -80,5 +80,5 @@ class GoogleStorage(Storage):
     def delete_directory(self):
         bucket = self._get_bucket()
 
-        for blob in bucket.list_blobs(self._parsed_storage_uri.path[1:] + "/"):
+        for blob in bucket.list_blobs(prefix=self._parsed_storage_uri.path[1:] + "/"):
             blob.delete()

--- a/storage/google_storage.py
+++ b/storage/google_storage.py
@@ -81,4 +81,5 @@ class GoogleStorage(Storage):
         bucket = self._get_bucket()
 
         for blob in bucket.list_blobs(prefix=self._parsed_storage_uri.path[1:] + "/"):
-            blob.delete()
+            unversioned_blob = bucket.blob(blob.name)
+            unversioned_blob.delete()

--- a/tests/test_google_storage.py
+++ b/tests/test_google_storage.py
@@ -439,7 +439,7 @@ class TestGoogleStorage(TestCase):
 
         self.assert_gets_bucket_with_credentials()
 
-        self.mock_bucket.list_blobs.assert_called_once_with("path/filename/")
+        self.mock_bucket.list_blobs.assert_called_once_with(prefix="path/filename/")
 
         mock_blobs[0].delete.assert_called_once_with()
         mock_blobs[1].delete.assert_called_once_with()

--- a/tests/test_google_storage.py
+++ b/tests/test_google_storage.py
@@ -430,8 +430,21 @@ class TestGoogleStorage(TestCase):
         self.assertEqual(0, mock_blobs[2].upload_from_filename.call_count)
 
     def test_delete_directory_deletes_blobs_with_prefix(self):
-        mock_blobs = [mock.Mock(), mock.Mock(), mock.Mock()]
-        self.mock_bucket.list_blobs.return_value = iter(mock_blobs)
+        mock_listed_blobs = [
+            self._mock_blob("path/filename/file1"),
+            self._mock_blob("path/filename/file2"),
+            self._mock_blob("path/filename/file3")
+        ]
+        self.mock_bucket.list_blobs.return_value = iter(mock_listed_blobs)
+
+        mock_unversioned_blobs = [
+            self._mock_blob("path/filename/file1"),
+            self._mock_blob("path/filename/file2"),
+            self._mock_blob("path/filename/file3")
+        ]
+        self.mock_bucket.blob.side_effect = mock_unversioned_blobs
+
+        self.mock_bucket.list_blobs.return_value = iter(mock_listed_blobs)
 
         storage = get_storage("gs://{}@bucketname/path/filename".format(self.credentials))
 
@@ -441,9 +454,15 @@ class TestGoogleStorage(TestCase):
 
         self.mock_bucket.list_blobs.assert_called_once_with(prefix="path/filename/")
 
-        mock_blobs[0].delete.assert_called_once_with()
-        mock_blobs[1].delete.assert_called_once_with()
-        mock_blobs[2].delete.assert_called_once_with()
+        self.mock_bucket.blob.assert_has_calls([
+            mock.call("path/filename/file1"),
+            mock.call("path/filename/file2"),
+            mock.call("path/filename/file3")
+        ])
+
+        mock_unversioned_blobs[0].delete.assert_called_once_with()
+        mock_unversioned_blobs[1].delete.assert_called_once_with()
+        mock_unversioned_blobs[2].delete.assert_called_once_with()
 
     def test_storage_uris_can_be_unicode(self):
         storage = get_storage(u"gs://{}@bucketname/path/filename".format(self.credentials))


### PR DESCRIPTION
We discovered an issue with deleting directories from google, where we call `list_blobs` with the wrong arguments, generating an error and causing the entire deletion to fail.

Also, we ported the fix for handling blob generation numbers changing between the list and the access from the `save_to_directory` implementation, since `delete_directory` could be subject to the same issue.

@ustudio/reviewers Please review