### PR TITLE
Set content disposition for download urls (v0.12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install via pip:
 pip install object_storage
 ```
 
-The current version is `0.12.5`.
+The current version is `0.12.6`.
 
 ## Quick Start ##
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
 ]
 
 setup(name="object_storage",
-      version="0.12.5",
+      version="0.12.6",
       description="Python library for accessing files over various file transfer protocols.",
       url="https://github.com/ustudio/storage",
       packages=["storage"],

--- a/storage/google_storage.py
+++ b/storage/google_storage.py
@@ -47,7 +47,9 @@ class GoogleStorage(Storage):
 
     def get_download_url(self, seconds=60, key=None):
         blob = self._get_blob()
-        return blob.generate_signed_url(datetime.timedelta(seconds=seconds))
+        return blob.generate_signed_url(
+            expiration=datetime.timedelta(seconds=seconds),
+            response_disposition="attachment")
 
     def save_to_directory(self, directory_path):
         bucket = self._get_bucket()

--- a/tests/test_google_storage.py
+++ b/tests/test_google_storage.py
@@ -104,21 +104,27 @@ class TestGoogleStorage(TestCase):
         self.assert_gets_bucket_with_credentials()
 
         self.mock_bucket.blob.assert_called_once_with("path/filename")
-        self.mock_blob.generate_signed_url.assert_called_once_with(datetime.timedelta(seconds=60))
+        self.mock_blob.generate_signed_url.assert_called_once_with(
+            expiration=datetime.timedelta(seconds=60),
+            response_disposition="attachment")
 
     def test_get_download_url_returns_signed_url_with_provided_expiration(self):
         storage = get_storage("gs://{}@bucketname/path/filename".format(self.credentials))
 
         storage.get_download_url(1000)
 
-        self.mock_blob.generate_signed_url.assert_called_once_with(datetime.timedelta(seconds=1000))
+        self.mock_blob.generate_signed_url.assert_called_once_with(
+            expiration=datetime.timedelta(seconds=1000),
+            response_disposition="attachment")
 
     def test_get_download_url_does_not_use_key_when_provided(self):
         storage = get_storage("gs://{}@bucketname/path/filename".format(self.credentials))
 
         storage.get_download_url(key="KEY")
 
-        self.mock_blob.generate_signed_url.assert_called_once_with(datetime.timedelta(seconds=60))
+        self.mock_blob.generate_signed_url.assert_called_once_with(
+            expiration=datetime.timedelta(seconds=60),
+            response_disposition="attachment")
 
     def _mock_blob(self, name):
         blob = mock.Mock()


### PR DESCRIPTION
This updates the `get_download_url` method for Google storage objects to make the resulting download URL set the `Content-Disposition` response header in order to instruct the browser to download the content instead of displaying it inline.

@ustudio/reviewers Please review