### PR TITLE
Set content disposition for download urls (v0.13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install via pip:
 pip install object_storage
 ```
 
-The current version is `0.13.0`.
+The current version is `0.13.1`.
 
 ## Quick Start ##
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
 ]
 
 setup(name="object_storage",
-      version="0.13.0",
+      version="0.13.1",
       description="Python library for accessing files over various file transfer protocols.",
       url="https://github.com/ustudio/storage",
       packages=["storage"],

--- a/storage/google_storage.py
+++ b/storage/google_storage.py
@@ -53,7 +53,9 @@ class GoogleStorage(Storage):
 
     def get_download_url(self, seconds: int = 60, key: Optional[str] = None) -> str:
         blob = self._get_blob()
-        return blob.generate_signed_url(datetime.timedelta(seconds=seconds))
+        return blob.generate_signed_url(
+            expiration=datetime.timedelta(seconds=seconds),
+            response_disposition="attachment")
 
     def save_to_directory(self, directory_path: str) -> None:
         bucket = self._get_bucket()

--- a/stubs/google/cloud/storage/blob.pyi
+++ b/stubs/google/cloud/storage/blob.pyi
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from typing import BinaryIO
+from typing import BinaryIO, Optional
 
 
 class Blob(object):
@@ -17,4 +17,6 @@ class Blob(object):
 
     def delete(self) -> None: ...
 
-    def generate_signed_url(self, expires: timedelta) -> str: ...
+    def generate_signed_url(
+        self, expiration: Optional[timedelta] = None,
+        response_disposition: Optional[str] = None) -> str: ...

--- a/tests/swift_service_test_case.py
+++ b/tests/swift_service_test_case.py
@@ -162,17 +162,24 @@ class SwiftServiceTestCase(ServiceTestCase):
             self, environ: "Environ", start_response: "StartResponse") -> List[bytes]:
         path = environ["REQUEST_PATH"].split("CONTAINER")[1]
 
+        while True:
+            header = b""
+            while not header.endswith(b"\r\n"):
+                header += environ["wsgi.input"].read(1)
+
+            body_size = int(header.strip())
+            contents = environ["wsgi.input"].read(body_size)
+            environ["wsgi.input"].read(2)  # read trailing "\r\n"
+
+            if body_size == 0:
+                break
+
+            self.container_contents[path] = contents
+
         if len(self.remaining_object_put_failures) > 0:
             failure = self.remaining_object_put_failures.pop(0)
             start_response(failure, [("Content-type", "text/plain")])
             return [b"Internal server error"]
-
-        header = b""
-        while not header.endswith(b"\r\n"):
-            header += environ["wsgi.input"].read(1)
-
-        body_size = int(header.strip())
-        self.container_contents[path] = environ["wsgi.input"].read(body_size)
 
         start_response("201 OK", [("Content-type", "text/plain")])
         return [b""]

--- a/tests/swift_service_test_case.py
+++ b/tests/swift_service_test_case.py
@@ -162,19 +162,20 @@ class SwiftServiceTestCase(ServiceTestCase):
             self, environ: "Environ", start_response: "StartResponse") -> List[bytes]:
         path = environ["REQUEST_PATH"].split("CONTAINER")[1]
 
+        contents = b""
         while True:
             header = b""
             while not header.endswith(b"\r\n"):
                 header += environ["wsgi.input"].read(1)
 
             body_size = int(header.strip())
-            contents = environ["wsgi.input"].read(body_size)
+            contents += environ["wsgi.input"].read(body_size)
             environ["wsgi.input"].read(2)  # read trailing "\r\n"
 
             if body_size == 0:
                 break
 
-            self.container_contents[path] = contents
+        self.container_contents[path] = contents
 
         if len(self.remaining_object_put_failures) > 0:
             failure = self.remaining_object_put_failures.pop(0)

--- a/tests/test_google_storage.py
+++ b/tests/test_google_storage.py
@@ -102,21 +102,27 @@ class TestGoogleStorage(TestCase):
         self.assert_gets_bucket_with_credentials()
 
         self.mock_bucket.blob.assert_called_once_with("path/filename")
-        self.mock_blob.generate_signed_url.assert_called_once_with(datetime.timedelta(seconds=60))
+        self.mock_blob.generate_signed_url.assert_called_once_with(
+            expiration=datetime.timedelta(seconds=60),
+            response_disposition="attachment")
 
     def test_get_download_url_returns_signed_url_with_provided_expiration(self) -> None:
         storage = get_storage("gs://{}@bucketname/path/filename".format(self.credentials))
 
         storage.get_download_url(1000)
 
-        self.mock_blob.generate_signed_url.assert_called_once_with(datetime.timedelta(seconds=1000))
+        self.mock_blob.generate_signed_url.assert_called_once_with(
+            expiration=datetime.timedelta(seconds=1000),
+            response_disposition="attachment")
 
     def test_get_download_url_does_not_use_key_when_provided(self) -> None:
         storage = get_storage("gs://{}@bucketname/path/filename".format(self.credentials))
 
         storage.get_download_url(key="KEY")
 
-        self.mock_blob.generate_signed_url.assert_called_once_with(datetime.timedelta(seconds=60))
+        self.mock_blob.generate_signed_url.assert_called_once_with(
+            expiration=datetime.timedelta(seconds=60),
+            response_disposition="attachment")
 
     def _mock_blob(self, name: str) -> mock.Mock:
         blob = mock.Mock()


### PR DESCRIPTION
This is essentially the same as #50 but for the master branch, where only Python 3 is supported.

In addition to the download URL update, this change also fixes the intermittent test failures we've been experiencing in the Swift storage implementation tests. The problem was that the fake Swift server wasn't reading the entire chunked transfer before closing the connection, so the client would occasionally encounter "Broken pipe" errors while trying to send the chunked transfer. I have updated the fake server to read the entire chunked transfer, including the terminating 0-byte chunk at the end.

Lastly, I split the single `event` used for signalling between threads in the service case helpers to make he code a little easier to understand and to avoid some unnecessary looping.

@ustudio/reviewers Please review