### PR TITLE
Make package PEP 561 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install via pip:
 pip install object_storage
 ```
 
-The current version is `0.13.2`.
+The current version is `0.13.3`.
 
 ## Quick Start ##
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
 ]
 
 setup(name="object_storage",
-      version="0.13.2",
+      version="0.13.3",
       description="Python library for accessing files over various file transfer protocols.",
       url="https://github.com/ustudio/storage",
       packages=["storage"],

--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,5 @@ setup(name="object_storage",
       description="Python library for accessing files over various file transfer protocols.",
       url="https://github.com/ustudio/storage",
       packages=["storage"],
+      package_data={"storage": ["py.typed"]},
       install_requires=install_requires)


### PR DESCRIPTION
PEP 561 requires a package to include a `py.typed` file in order to use the type annotations in consuming projects. This adds that file to make it compatible.

@ustudio/reviewers Please review