### PR TITLE
Correctly set Content Type with Google Storage and Amazon S3 in 0.12 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install via pip:
 pip install object_storage
 ```
 
-The current version is `0.12.7`.
+The current version is `0.12.8`.
 
 ## Quick Start ##
 

--- a/integration-tests.py
+++ b/integration-tests.py
@@ -40,6 +40,12 @@ class IntegrationTests(unittest.TestCase):
             os.write(handle, contents)
             os.close(handle)
 
+            handle, _ = tempfile.mkstemp(
+                prefix="source-mimetyped-file", suffix=".png",
+                dir=tempfile.mkdtemp(prefix="source-contentdir", dir=cls.directory))
+            os.write(handle, contents)
+            os.close(handle)
+
     @classmethod
     def tearDownClass(cls):
         shutil.rmtree(cls.directory)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
 ]
 
 setup(name="object_storage",
-      version="0.12.7",
+      version="0.12.8",
       description="Python library for accessing files over various file transfer protocols.",
       url="https://github.com/ustudio/storage",
       packages=["storage"],

--- a/storage/google_storage.py
+++ b/storage/google_storage.py
@@ -1,6 +1,7 @@
 import base64
 import datetime
 import json
+import mimetypes
 import os
 
 import google.cloud.storage
@@ -39,7 +40,7 @@ class GoogleStorage(Storage):
 
     def load_from_file(self, in_file):
         blob = self._get_blob()
-        blob.upload_from_file(in_file)
+        blob.upload_from_file(in_file, content_type=mimetypes.guess_type(self._storage_uri)[0])
 
     def delete(self):
         blob = self._get_blob()

--- a/storage/storage.py
+++ b/storage/storage.py
@@ -141,5 +141,8 @@ class InvalidStorageUri(RuntimeError):
 
 
 def get_storage(storage_uri):
-    storage_type = storage_uri.split("://")[0]
-    return _STORAGE_TYPES[storage_type](storage_uri)
+    storage_type = urlparse.urlparse(storage_uri).scheme
+    try:
+        return _STORAGE_TYPES[storage_type](storage_uri)
+    except KeyError:
+        raise InvalidStorageUri("Invalid storage type '{}'".format(storage_type))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 
 
-def create_temp_nested_directory_with_files():
+def create_temp_nested_directory_with_files(suffixes=["", "", ""]):
     # temp_directory/
     #   temp_input_one
     #   temp_input_two
@@ -11,7 +11,8 @@ def create_temp_nested_directory_with_files():
     temp_dir = {}
     temp_dir["temp_directory"] = {"path": tempfile.mkdtemp()}
     temp_dir["temp_input_one"] = {
-        "file": tempfile.NamedTemporaryFile(dir=temp_dir["temp_directory"]["path"])}
+        "file": tempfile.NamedTemporaryFile(
+            dir=temp_dir["temp_directory"]["path"], suffix=suffixes[0])}
     temp_dir["temp_input_one"]["path"] = temp_dir["temp_input_one"]["file"].name
     temp_dir["temp_input_one"]["name"] = os.path.basename(temp_dir["temp_input_one"]["file"].name)
 
@@ -19,7 +20,8 @@ def create_temp_nested_directory_with_files():
     temp_dir["temp_input_one"]["file"].flush()
 
     temp_dir["temp_input_two"] = {
-        "file": tempfile.NamedTemporaryFile(dir=temp_dir["temp_directory"]["path"])}
+        "file": tempfile.NamedTemporaryFile(
+            dir=temp_dir["temp_directory"]["path"], suffix=suffixes[1])}
     temp_dir["temp_input_two"]["path"] = temp_dir["temp_input_two"]["file"].name
     temp_dir["temp_input_two"]["name"] = os.path.basename(temp_dir["temp_input_two"]["file"].name)
     temp_dir["temp_input_two"]["file"].write("BAR")
@@ -31,7 +33,8 @@ def create_temp_nested_directory_with_files():
         temp_dir["nested_temp_directory"]["path"])
 
     temp_dir["nested_temp_input"] = {
-        "file": tempfile.NamedTemporaryFile(dir=temp_dir["nested_temp_directory"]["path"])}
+        "file": tempfile.NamedTemporaryFile(
+            dir=temp_dir["nested_temp_directory"]["path"], suffix=suffixes[2])}
     temp_dir["nested_temp_input"]["path"] = temp_dir["nested_temp_input"]["file"].name
     temp_dir["nested_temp_input"]["name"] = os.path.basename(
         temp_dir["nested_temp_input"]["file"].name)

--- a/tests/test_google_storage.py
+++ b/tests/test_google_storage.py
@@ -80,7 +80,16 @@ class TestGoogleStorage(TestCase):
         self.assert_gets_bucket_with_credentials()
 
         self.mock_bucket.blob.assert_called_once_with("path/filename")
-        self.mock_blob.upload_from_file.assert_called_once_with(mock_file)
+        self.mock_blob.upload_from_file.assert_called_once_with(mock_file, content_type=None)
+
+    def test_load_from_file_guesses_content_type_based_on_filename(self):
+        mock_file = mock.Mock()
+
+        storage = get_storage("gs://{}@bucketname/path/whatever.html".format(self.credentials))
+
+        storage.load_from_file(mock_file)
+
+        self.mock_blob.upload_from_file.assert_called_once_with(mock_file, content_type="text/html")
 
     def test_delete_deletes_blob(self):
         storage = get_storage("gs://{}@bucketname/path/filename".format(self.credentials))

--- a/tests/test_s3_storage.py
+++ b/tests/test_s3_storage.py
@@ -52,6 +52,21 @@ class TestS3Storage(TestCase):
 
         mock_s3.put_object.assert_called_with(Bucket="bucket", Key="some/file", Body=mock_file)
 
+    @mock.patch("boto3.session.Session", autospec=True)
+    def test_load_from_file_guesses_content_type_based_on_filename(self, mock_session_class):
+        mock_session = mock_session_class.return_value
+        mock_s3 = mock_session.client.return_value
+
+        mock_file = mock.Mock()
+
+        storage = storagelib.get_storage(
+            "s3://access_key:access_secret@bucket/some/whatever.jpg")
+
+        storage.load_from_file(mock_file)
+
+        mock_s3.put_object.assert_called_with(
+            Bucket="bucket", Key="some/whatever.jpg", Body=mock_file, ContentType="image/jpeg")
+
     @mock.patch("boto3.s3.transfer.S3Transfer", autospec=True)
     @mock.patch("boto3.session.Session", autospec=True)
     def test_load_from_filename(self, mock_session_class, mock_transfer_class):
@@ -73,7 +88,22 @@ class TestS3Storage(TestCase):
 
         mock_transfer_class.assert_called_with(mock_s3)
 
-        mock_transfer.upload_file.assert_called_with("source/file", "bucket", "some/file")
+        mock_transfer.upload_file.assert_called_with(
+            "source/file", "bucket", "some/file", extra_args=None)
+
+    @mock.patch("boto3.s3.transfer.S3Transfer", autospec=True)
+    @mock.patch("boto3.session.Session", autospec=True)
+    def test_load_from_filename_guess_content_type_based_on_filename(
+            self, mock_session_class, mock_transfer_class):
+        mock_transfer = mock_transfer_class.return_value
+
+        storage = storagelib.get_storage(
+            "s3://access_key:access_secret@bucket/some/file")
+
+        storage.load_from_filename("source/whatever.jpg")
+
+        mock_transfer.upload_file.assert_called_with(
+            "source/whatever.jpg", "bucket", "some/file", extra_args={"ContentType": "image/jpeg"})
 
     @mock.patch("boto3.session.Session", autospec=True)
     def test_save_to_file(self, mock_session_class):
@@ -375,7 +405,7 @@ class TestS3Storage(TestCase):
         mock_session = mock_session_class.return_value
         mock_s3_client = mock_session.client.return_value
 
-        temp_directory = create_temp_nested_directory_with_files()
+        temp_directory = create_temp_nested_directory_with_files(suffixes=[".js", ".unknown", ""])
 
         storage = storagelib.get_storage(
             "s3://access_key:access_secret@bucket/dir?region=US_EAST")
@@ -385,15 +415,18 @@ class TestS3Storage(TestCase):
         mock_s3_client.upload_file.assert_has_calls([
             mock.call(
                 temp_directory["temp_input_two"]["path"], "bucket",
-                os.path.join("dir", temp_directory["temp_input_two"]["name"])),
+                os.path.join("dir", temp_directory["temp_input_two"]["name"]),
+                ExtraArgs=None),
             mock.call(
                 temp_directory["temp_input_one"]["path"], "bucket",
-                os.path.join("dir", temp_directory["temp_input_one"]["name"])),
+                os.path.join("dir", temp_directory["temp_input_one"]["name"]),
+                ExtraArgs={"ContentType": "application/javascript"}),
             mock.call(
                 temp_directory["nested_temp_input"]["path"], "bucket",
                 os.path.join(
                     "dir", temp_directory["nested_temp_directory"]["name"],
-                    temp_directory["nested_temp_input"]["name"]))
+                    temp_directory["nested_temp_input"]["name"]),
+                ExtraArgs=None)
         ], any_order=True)
 
     @mock.patch("storage.retry.time.sleep", autospec=True)
@@ -423,15 +456,18 @@ class TestS3Storage(TestCase):
         mock_s3_client.upload_file.assert_has_calls([
             mock.call(
                 temp_directory["temp_input_two"]["path"], "bucket",
-                os.path.join("dir", temp_directory["temp_input_two"]["name"])),
+                os.path.join("dir", temp_directory["temp_input_two"]["name"]),
+                ExtraArgs=None),
             mock.call(
                 temp_directory["temp_input_one"]["path"], "bucket",
-                os.path.join("dir", temp_directory["temp_input_one"]["name"])),
+                os.path.join("dir", temp_directory["temp_input_one"]["name"]),
+                ExtraArgs=None),
             mock.call(
                 temp_directory["nested_temp_input"]["path"], "bucket",
                 os.path.join(
                     "dir", temp_directory["nested_temp_directory"]["name"],
-                    temp_directory["nested_temp_input"]["name"]))
+                    temp_directory["nested_temp_input"]["name"]),
+                ExtraArgs=None)
         ], any_order=True)
         self.assertEqual(
             mock_s3_client.upload_file.call_args_list[1],

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -4,7 +4,7 @@ import threading
 from unittest import TestCase
 
 import storage as storagelib
-from storage.storage import Storage
+from storage.storage import Storage, InvalidStorageUri
 
 
 class TestTimeout(TestCase):
@@ -54,6 +54,26 @@ class TestRegisterStorageProtocol(TestCase):
         uri = "{0}://some/uri/path".format(self.scheme)
         store_obj = storagelib.get_storage(uri)
         self.assertIsInstance(store_obj, MyStorageClass)
+
+
+class TestGetStorage(TestCase):
+    def test_raises_for_unsupported_scheme(self):
+        with self.assertRaises(InvalidStorageUri) as error:
+            storagelib.get_storage("unsupported://creds:secret@bucket/path")
+
+        self.assertEqual("Invalid storage type 'unsupported'", str(error.exception))
+
+    def test_raises_for_missing_scheme(self):
+        with self.assertRaises(InvalidStorageUri) as error:
+            storagelib.get_storage("//creds:secret@invalid/storage/uri")
+
+        self.assertEqual("Invalid storage type ''", str(error.exception))
+
+    def test_raises_for_missing_scheme_and_netloc(self):
+        with self.assertRaises(InvalidStorageUri) as error:
+            storagelib.get_storage("invalid/storage/uri")
+
+        self.assertEqual("Invalid storage type ''", str(error.exception))
 
 
 class TestStorage(TestCase):


### PR DESCRIPTION
This PR implements the same changes as #56 but in the 0.12 branch, for projects still using Python 2.7.

@ustudio/reviewers Please review