### PR TITLE
Update Swift Storage to Correctly Handle Directory Placeholder Objects

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 100
-ignore=
+ignore=W503

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install via pip:
 pip install object_storage
 ```
 
-The current version is `0.12.8`.
+The current version is `0.12.9`.
 
 ## Quick Start ##
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
 ]
 
 setup(name="object_storage",
-      version="0.12.8",
+      version="0.12.9",
       description="Python library for accessing files over various file transfer protocols.",
       url="https://github.com/ustudio/storage",
       packages=["storage"],

--- a/storage/swift_storage.py
+++ b/storage/swift_storage.py
@@ -86,7 +86,8 @@ class SwiftStorage(Storage):
         files = []
 
         for container_object in container_objects:
-            if container_object.content_type == "application/directory":
+            if container_object.content_type == "application/directory" \
+                    or container_object.name.endswith("/"):
                 directories.append(container_object)
             else:
                 files.append(container_object)
@@ -115,7 +116,7 @@ class SwiftStorage(Storage):
             if directory.name == prefix:
                 continue
 
-            directory_path = directory.name.split('/', 1).pop()
+            directory_path = directory.name.rstrip('/').split('/', 1).pop()
             target_directory = os.path.join(destination_directory, directory_path)
 
             if not os.path.exists(target_directory):


### PR DESCRIPTION
Rackspace CloudFiles appears to no longer return the `application/directory` content type for directory placeholder objects. This PR updates the code to use the name of the object to determine if it is a placeholder object, in addition to the content type.

We also updated the test to be a little more representative of the actual behavior of the PyRax library.

@ustudio/reviewers Please review