### PR TITLE
Fix Swift save_to_directory for swiftclient based implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install via pip:
 pip install object_storage
 ```
 
-The current version is `0.14.1`.
+The current version is `0.14.2`.
 For Python 2.7, use the latest release from the `v0.12` branch.
 
 ## Quick Start ##

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
 ]
 
 setup(name="object_storage",
-      version="0.14.1",
+      version="0.14.2",
       description="Python library for accessing files over various file transfer protocols.",
       url="https://github.com/ustudio/storage",
       packages=["storage"],

--- a/storage/swift_storage.py
+++ b/storage/swift_storage.py
@@ -180,6 +180,9 @@ class SwiftStorage(Storage):
         prefix = self._parsed_storage_uri.path[1:] + "/"
 
         for container_object in self._find_storage_objects_with_prefix(container, prefix):
+            if container_object["name"].endswith("/"):
+                continue
+
             base_path = container_object["name"].split(prefix)[1]
             relative_path = os.path.sep.join(base_path.split("/"))
             file_path = os.path.join(directory_path, relative_path)

--- a/tests/swift_service_test_case.py
+++ b/tests/swift_service_test_case.py
@@ -221,7 +221,7 @@ class SwiftServiceTestCase(ServiceTestCase):
         written_files = {}
         expected_files = {
             strip_slashes(f.split(object_path)[1]): v
-            for f, v in self.container_contents.items()
+            for f, v in self.container_contents.items() if not f.endswith("/")
         }
 
         for root, dirs, files in os.walk(self.tmp_dir.name):

--- a/tests/test_swift_storage.py
+++ b/tests/test_swift_storage.py
@@ -788,6 +788,21 @@ class TestSwiftStorageProvider(StorageTestCase, SwiftServiceTestCase):
 
         self.assert_container_contents_equal("/path/to/files")
 
+    def test_save_to_directory_ignores_directory_placeholder_objects(self) -> None:
+        self._add_file_to_directory("/path/to/files/file.mp4", b"Contents")
+        self._add_file_to_directory("/path/to/files/other_file.mp4", b"Other Contents")
+        self._add_file_to_directory("/path/to/files/folder/", b"")
+        self._add_file_to_directory("/path/to/files/folder/file2.mp4", b"Video Content")
+        self._add_file_to_directory("/path/to/files/folder2/folder3/files3.mp4", b"Video Contents")
+
+        swift_uri = self._generate_storage_uri("/path/to/files")
+        storage_object = get_storage(swift_uri)
+
+        with self.run_services():
+            storage_object.save_to_directory(self.tmp_dir.name)
+
+        self.assert_container_contents_equal("/path/to/files")
+
     def test_save_to_directory_retries_on_error(self) -> None:
         self.remaining_file_failures.append("500 Internal server error")
         self._add_file_to_directory("/path/to/files/file.mp4", b"Contents")


### PR DESCRIPTION
This implements the same fix as #58 , but for the Python 3 code, which uses `python-swiftclient` instead of `pyrax`.

@ustudio/reviewers Please review