### PR TITLE
Use CircleCI Contexts for Credentials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,17 @@
-version: 2
+version: 2.1
 jobs:
   test:
+    parameters:
+      python_version:
+        description: "The Python version to use for running the tests"
+        type: string
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:<< parameters.python_version >>
+        environment:
+          TEST_STORAGE_FILE_URI: file:///tmp/integration-tests
+          TEST_STORAGE_FTP_URI: ftp://files:password@localhost/integration-tests
+          # TEST_STORAGE_GS_URI in CircleCI context
+          # TEST_STORAGE_S3_URI in CircleCI context
       - image: onjin/alpine-vsftpd:latest
         environment:
           PASSWORD: password
@@ -12,15 +21,17 @@ jobs:
           echo 'allow_writeable_chroot=YES' >> /etc/vsftpd/vsftpd.conf;
           /docker-entrypoint.sh"
 
-    working_directory: ~/repo
-
     steps:
       - checkout
 
+      - run:
+          name: Save Python Version
+          command: |
+            python --version > pythonversion
+
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "requirements.txt" }}
-            - v1-dependencies-
+            - v1-python-{{ checksum "pythonversion" }}-dependencies-{{ checksum "requirements.txt" }}
 
       - run:
           name: install dependencies
@@ -34,7 +45,7 @@ jobs:
       - save_cache:
           paths:
             - ~/venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
+          key: v1-python-{{ checksum "pythonversion" }}-dependencies-{{ checksum "requirements.txt" }}
 
       - run:
           name: run tests
@@ -56,73 +67,11 @@ jobs:
 
       - store_artifacts:
           path: test-reports
-          prefix: python-3.7
+          prefix: python-<< parameters.python_version >>
 
       - store_test_results:
           path: test-reports
-          prefix: python-3.7
-
-  test-3.6:
-    docker:
-      - image: circleci/python:3.6
-      - image: onjin/alpine-vsftpd:latest
-        environment:
-          PASSWORD: password
-        command: >
-          sh -c
-          "sed -i -e 's#/home/./files#/home/files/./#' /etc/passwd;
-          echo 'allow_writeable_chroot=YES' >> /etc/vsftpd/vsftpd.conf;
-          /docker-entrypoint.sh"
-
-    working_directory: ~/repo
-
-    steps:
-      - checkout
-
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "requirements.txt" }}
-            - v1-dependencies-
-
-      - run:
-          name: install dependencies
-          command: |
-            python -m virtualenv ~/venv
-            . ~/venv/bin/activate
-            pip install -e .
-            pip install -r requirements.txt
-            mkdir -p test-reports
-
-      - save_cache:
-          paths:
-            - ~/venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
-
-      - run:
-          name: run tests
-          command: |
-            . ~/venv/bin/activate
-            pytest --verbose --junit-xml=test-reports/pytest.xml
-
-      - run:
-          name: run linter
-          command: |
-            . ~/venv/bin/activate
-            flake8 | tee test-reports/flake8-errors
-
-      - run:
-          name: run typechecks
-          command: |
-            . ~/venv/bin/activate
-            MYPYPATH=stubs mypy --strict storage/ tests/
-
-      - store_artifacts:
-          path: test-reports
-          prefix: python-3.6
-
-      - store_test_results:
-          path: test-reports
-          prefix: python-3.6
+          prefix: python-<< parameters.python_version >>
 
   publish:
     docker:
@@ -158,20 +107,26 @@ workflows:
   test-and-build:
     jobs:
       - test:
+          name: test-3.9
+          python_version: "3.9"
           filters:
             tags:
               only: /.*/
-      - test-3.6:
+          context: storage-library-tester
+      - test:
+          name: test-3.7
+          python_version: "3.7"
           filters:
             tags:
               only: /.*/
+          context: storage-library-tester
       - publish:
           requires:
-            - test
-            - test-3.6
+            - test-3.9
+            - test-3.7
           filters:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*.*/
             branches:
               ignore: /.*/
-          context: org-global
+          context: storage-library-publisher

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,8 +107,8 @@ workflows:
   test-and-build:
     jobs:
       - test:
-          name: test-3.9
-          python_version: "3.9"
+          name: test-3.5
+          python_version: "3.5"
           filters:
             tags:
               only: /.*/
@@ -122,7 +122,7 @@ workflows:
           context: storage-library-tester
       - publish:
           requires:
-            - test-3.9
+            - test-3.5
             - test-3.7
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,8 +107,8 @@ workflows:
   test-and-build:
     jobs:
       - test:
-          name: test-3.5
-          python_version: "3.5"
+          name: test-3.6
+          python_version: "3.6"
           filters:
             tags:
               only: /.*/
@@ -122,7 +122,7 @@ workflows:
           context: storage-library-tester
       - publish:
           requires:
-            - test-3.5
+            - test-3.6
             - test-3.7
           filters:
             tags:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 atomicwrites==1.3.0
-attrs==19.1.0
+attrs==22.2.0
 boto3==1.17.87
 botocore==1.20.87
 cachetools==3.1.1
@@ -7,6 +7,7 @@ certifi==2019.6.16
 chardet==3.0.4
 docutils==0.15.2
 entrypoints==0.3
+exceptiongroup==1.1.0
 flake8==3.7.8
 google-api-core==1.14.2
 google-auth==1.6.3
@@ -15,7 +16,8 @@ google-cloud-storage==1.18.0
 google-resumable-media==0.3.2
 googleapis-common-protos==1.6.0
 idna==2.8
-importlib-metadata==0.19
+importlib-metadata==6.0.0
+iniconfig==2.0.0
 iso8601==0.1.12
 jmespath==0.10.0
 keystoneauth==0.5.0
@@ -35,7 +37,7 @@ pyasn1-modules==0.2.6
 pycodestyle==2.5.0
 pyflakes==2.1.1
 pyparsing==2.4.2
-pytest==5.1.1
+pytest==7.2.1
 python-dateutil==2.8.1
 python-swiftclient==4.1.0
 pytz==2019.2
@@ -44,6 +46,7 @@ rsa==4.7
 s3transfer==0.4.2
 six==1.16.0
 stevedore==1.30.1
+tomli==2.0.1
 typed-ast==1.4.0
 typing-extensions==3.7.4
 urllib3==1.26.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ s3transfer==0.4.2
 six==1.16.0
 stevedore==1.30.1
 tomli==2.0.1
-typed-ast==1.4.0
+typed-ast==1.4.1
 typing-extensions==3.7.4
 urllib3==1.26.5
 wcwidth==0.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 atomicwrites==1.3.0
-attrs==22.2.0
+attrs==19.1.0
 boto3==1.17.87
 botocore==1.20.87
 cachetools==3.1.1
@@ -7,7 +7,6 @@ certifi==2019.6.16
 chardet==3.0.4
 docutils==0.15.2
 entrypoints==0.3
-exceptiongroup==1.1.0
 flake8==3.7.8
 google-api-core==1.14.2
 google-auth==1.6.3
@@ -16,8 +15,7 @@ google-cloud-storage==1.18.0
 google-resumable-media==0.3.2
 googleapis-common-protos==1.6.0
 idna==2.8
-importlib-metadata==6.0.0
-iniconfig==2.0.0
+importlib-metadata==0.19
 iso8601==0.1.12
 jmespath==0.10.0
 keystoneauth==0.5.0
@@ -37,7 +35,7 @@ pyasn1-modules==0.2.6
 pycodestyle==2.5.0
 pyflakes==2.1.1
 pyparsing==2.4.2
-pytest==7.2.1
+pytest==5.1.1
 python-dateutil==2.8.1
 python-swiftclient==4.1.0
 pytz==2019.2
@@ -46,7 +44,6 @@ rsa==4.7
 s3transfer==0.4.2
 six==1.16.0
 stevedore==1.30.1
-tomli==2.0.1
 typed-ast==1.4.1
 typing-extensions==3.7.4
 urllib3==1.26.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ pyflakes==2.1.1
 pyparsing==2.4.2
 pytest==5.1.1
 python-dateutil==2.8.1
-python-swiftclient==3.8.0
+python-swiftclient==4.1.0
 pytz==2019.2
 requests==2.25.1
 rsa==4.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ google-cloud-storage==1.18.0
 google-resumable-media==0.3.2
 googleapis-common-protos==1.6.0
 idna==2.8
-importlib-metadata==6.0.0
+importlib-metadata==4.8.3
 iso8601==0.1.12
 jmespath==0.10.0
 keystoneauth==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ google-cloud-storage==1.18.0
 google-resumable-media==0.3.2
 googleapis-common-protos==1.6.0
 idna==2.8
-importlib-metadata==0.19
+importlib-metadata==6.0.0
 iso8601==0.1.12
 jmespath==0.10.0
 keystoneauth==0.5.0

--- a/tests/test_s3_storage.py
+++ b/tests/test_s3_storage.py
@@ -710,7 +710,7 @@ class TestS3Storage(StorageTestCase, TestCase):
         mock_session = mock_session_class.return_value
         mock_s3_client = mock_session.client.return_value
 
-        self.temp_directory = create_temp_nested_directory_with_files([".js", ".unknown", ""])
+        self.temp_directory = create_temp_nested_directory_with_files([".png", ".unknown", ""])
 
         storage = get_storage(
             "s3://access_key:access_secret@bucket/dir?region=US_EAST")
@@ -725,7 +725,7 @@ class TestS3Storage(StorageTestCase, TestCase):
             mock.call(
                 self.temp_directory["temp_input_one"]["path"], "bucket",
                 os.path.join("dir", self.temp_directory["temp_input_one"]["name"]),
-                ExtraArgs={"ContentType": "application/javascript"}),
+                ExtraArgs={"ContentType": "image/png"}),
             mock.call(
                 self.temp_directory["nested_temp_input"]["path"], "bucket",
                 os.path.join(

--- a/tests/test_swift_storage.py
+++ b/tests/test_swift_storage.py
@@ -1,6 +1,6 @@
 import contextlib
 from io import BytesIO
-from hashlib import sha1
+from hashlib import sha256
 import hmac
 import json
 import os
@@ -733,7 +733,7 @@ class TestSwiftStorageProvider(StorageTestCase, SwiftServiceTestCase):
     def generate_signature(self, path: str, key: bytes, expires: int = 60) -> str:
         timestamp = time.time()
         raw_string = f"GET\n{timestamp + expires}\n/v2.0/1234/CONTAINER{path}"
-        return hmac.new(key, raw_string.encode("utf8"), sha1).hexdigest()
+        return hmac.new(key, raw_string.encode("utf8"), sha256).hexdigest()
 
     @mock.patch("time.time")
     def test_get_download_url_uses_download_url_key_by_default(self, mock_time: mock.Mock) -> None:


### PR DESCRIPTION
The primary purpose of this PR was to update the CircleCI configuration file to use contexts for managing the credentials which are used to run the integration tests as well as to publish the package to PyPI on release. This will make managing those credentials easier, and also separates the credentials so that jobs only have access to what they need.

In order to not duplicate the changes to the environment variables between the different test configurations, we took advantage of CircleCI's "Reusable Config" feature to template the test job, so it only needs to be defined once, and can be used to run tests in different Python versions with minimal duplication.

Once we pushed the changes to Circle, we ran into several issues caused by changing build images, which caused us to upgrade some of the libraries in the `requirements.txt`. Upgrading `python-swiftclient` switched from SHA1 to SHA256 hashes, so we had to upgrade the tests. Also, the new `cimg` images changed the mimetype database, so that JavaScript  files were reported as `text/javascript` (which is actually out-of-date). To resolve this problem more permanently, we picked a different extension that has a less ambiguous mime type.

Finally, we pulled in two dependabot fixes to upgrade libraries used during the test runs.

We will not trigger a new release from this change, because the changes only affect builds in CI, and don't have any impact on the code deployed to PyPI or installed into dependent projects.

@ustudio/reviewers Please review