### PR TITLE
Support Third-Party S3 Bucket Access

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ such as a `/`.
 
 #### JSON Credentials
 
-Credentials can also be provided as JSON in the URI's username field. Do not provide a
-password field when providing credentials as JSON. The JSON must be URL encoded to quote
+Credentials can also be provided as JSON in the URI's username field. Do not specify a
+password when providing credentials as JSON. The JSON must be URL encoded to quote
 special characters. For example:
 
 ```
@@ -266,7 +266,7 @@ The JSON credentials must contain the following required attributes:
 }
 ```
 
-The `version` must be `1`. Other version number support may be added in the future.
+The `version` must be `1`. Support for other version numbers may be added in the future.
 
 If the client needs to assume a role before accessing the bucket (for example, to
 access a bucket owned by a third party), include the `role`, `role_session_name`, and

--- a/README.md
+++ b/README.md
@@ -246,6 +246,44 @@ Note that the `aws_access_key` and `aws_secret_access_key` should be URL encoded
 unsafe characters, if necessary. This may be necessary as AWS sometimes includes characters
 such as a `/`.
 
+#### JSON Credentials
+
+Credentials can also be provided as JSON in the URI's username field. Do not provide a
+password field when providing credentials as JSON. The JSON must be URL encoded to quote
+special characters. For example:
+
+```
+s3://%7B%22version%22%3A1%2C%22key_id%22%3A%22ACCESS-KEY%22%2C%22access_secret%22%3A%22ACCESS-SECRET%22%7D@bucket/path/to/file
+```
+
+The JSON credentials must contain the following required attributes:
+
+```json
+{
+  "version": 1,
+  "key_id": "AKIAIOSFODNN7EXAMPLE",
+  "access_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY"
+}
+```
+
+The `version` must be `1`. Other version number support may be added in the future.
+
+If the client needs to assume a role before accessing the bucket (for example, to
+access a bucket owned by a third party), include the `role`, `role_session_name`, and
+`external_id` attributes in the JSON:
+
+```json
+{
+  "version": 1,
+  "key_id": "AKIAIOSFODNN7EXAMPLE",
+  "access_secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY",
+  "role": "arn:aws:iam::123456789012:role/demo",
+  "role_session_name": "testAssumeRoleSession",
+  "external_id": "123ABC"
+}
+```
+
+
 ### ftp ####
 
 A reference to a file on an FTP server. Username and passwords are supported.

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,4 +15,4 @@ implicit_reexport = False
 strict_equality = True
 extra_checks = True
 mypy_path = stubs
-files = storage/,tests/
+files = storage/,tests/,test_integration.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "object-storage"
-version = "0.14.4"
+version = "0.15.0"
 description = "Python library for accessing files over various file transfer protocols."
 authors = ["uStudio Developers <dev@ustudio.com>"]
 license = "Apache 2.0"

--- a/storage/__init__.py
+++ b/storage/__init__.py
@@ -6,3 +6,8 @@ from storage import ftp_storage  # noqa: F401
 from storage import s3_storage  # noqa: F401
 from storage import google_storage  # noqa: F401
 from storage.swift_storage import register_swift_protocol  # noqa: F401
+
+__all__ = [
+    "get_storage",
+    "NotFoundError"
+]

--- a/storage/s3_storage.py
+++ b/storage/s3_storage.py
@@ -8,7 +8,7 @@ import boto3.s3.transfer
 from botocore.exceptions import ClientError
 from botocore.session import Session
 
-from typing import BinaryIO, Dict, Optional
+from typing import BinaryIO, Optional
 
 from storage import retry
 from storage.storage import Storage, NotFoundError, register_storage_protocol, _LARGE_CHUNK
@@ -148,7 +148,7 @@ class S3Storage(Storage):
     def load_from_file(self, in_file: BinaryIO) -> None:
         client = self._connect()
 
-        extra_args: Dict[str, str] = {}
+        extra_args: dict[str, str] = {}
 
         content_type = mimetypes.guess_type(self._storage_uri)[0]
         if content_type is not None:

--- a/stubs/boto3/__init__.pyi
+++ b/stubs/boto3/__init__.pyi
@@ -1,0 +1,38 @@
+import botocore.session
+from typing import Literal, Optional, TypedDict
+
+
+class _AssumeRoleResponseCredentials(TypedDict):
+    AccessKeyId: str
+    SecretAccessKey: str
+    SessionToken: str
+    # Other fields omitted
+
+
+class _AssumeRoleResponse(TypedDict):
+    Credentials: _AssumeRoleResponseCredentials
+    # Other fields omitted
+
+
+class _STSClient:
+    def assume_role(
+        self,
+        *,
+        RoleArn: str,
+        RoleSessionName: str,
+        ExternalId: Optional[str] = None
+        # Other arguments omitted
+    ) -> _AssumeRoleResponse:
+        ...
+
+
+def client(
+    service_name: Literal["sts"],
+    aws_access_key_id: Optional[str] = None,
+    aws_secret_access_key: Optional[str] = None,
+    aws_session_token: Optional[str] = None,
+    region_name: Optional[str] = None,
+    botocore_session: Optional[botocore.session.Session] = None,
+    profile_name: Optional[str] = None
+) -> _STSClient:
+    ...

--- a/test_integration.py
+++ b/test_integration.py
@@ -88,6 +88,9 @@ class IntegrationTests(unittest.TestCase):
     def test_s3_transport_can_upload_and_download_directories(self) -> None:
         self.assert_transport_handles_directories("S3")
 
+    def test_s3_transport_with_json_credentials_can_upload_and_download_directories(self) -> None:
+        self.assert_transport_handles_directories("S3_JSON")
+
     def test_swift_transport_can_upload_and_download_directories(self) -> None:
         self.assert_transport_handles_directories("SWIFT")
 

--- a/test_integration.py
+++ b/test_integration.py
@@ -6,7 +6,6 @@ import string
 import tempfile
 import time
 import unittest
-from urllib.parse import urlparse
 
 from storage import get_storage
 
@@ -56,11 +55,8 @@ class IntegrationTests(unittest.TestCase):
             raise unittest.SkipTest("Skipping {} - define {} to test".format(transport, variable))
 
         uri += "/{}".format(self.dest_prefix)
-        parsed_url = urlparse(uri)
-        print(
-            "Testing using:", parsed_url.scheme, parsed_url.hostname, parsed_url.port,
-            parsed_url.path)
         storage = get_storage(uri)
+        print(f"Testing using: {storage.get_sanitized_uri()}")
 
         print("Transport:", transport)
         print("\t* Uploading")

--- a/test_integration.py
+++ b/test_integration.py
@@ -12,8 +12,11 @@ from storage import get_storage
 
 
 class IntegrationTests(unittest.TestCase):
+    dest_prefix: str
+    directory: str
+
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         cls.dest_prefix = "".join([random.choice(string.ascii_letters) for i in range(16)])
         cls.directory = tempfile.mkdtemp(prefix="source-root")
         contents = "storage-test-{}".format(time.time()).encode("utf8")
@@ -42,10 +45,10 @@ class IntegrationTests(unittest.TestCase):
             os.close(handle)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         shutil.rmtree(cls.directory)
 
-    def assert_transport_handles_directories(self, transport):
+    def assert_transport_handles_directories(self, transport: str) -> None:
         variable = "TEST_STORAGE_{}_URI".format(transport)
         uri = os.getenv(variable, None)
 
@@ -76,17 +79,17 @@ class IntegrationTests(unittest.TestCase):
             print("Diff output:\n{}".format(error.output))
             raise
 
-    def test_file_transport_can_upload_and_download_directories(self):
+    def test_file_transport_can_upload_and_download_directories(self) -> None:
         self.assert_transport_handles_directories("FILE")
 
-    def test_ftp_transport_can_upload_and_download_directories(self):
+    def test_ftp_transport_can_upload_and_download_directories(self) -> None:
         self.assert_transport_handles_directories("FTP")
 
-    def test_s3_transport_can_upload_and_download_directories(self):
+    def test_s3_transport_can_upload_and_download_directories(self) -> None:
         self.assert_transport_handles_directories("S3")
 
-    def test_swift_transport_can_upload_and_download_directories(self):
+    def test_swift_transport_can_upload_and_download_directories(self) -> None:
         self.assert_transport_handles_directories("SWIFT")
 
-    def test_gs_transport_can_upload_and_download_directories(self):
+    def test_gs_transport_can_upload_and_download_directories(self) -> None:
         self.assert_transport_handles_directories("GS")

--- a/tests/test_s3_storage.py
+++ b/tests/test_s3_storage.py
@@ -65,7 +65,7 @@ class TestS3Storage(StorageTestCase, TestCase):
         if external_id is not None:
             credentials["external_id"] = external_id
 
-        return quote(json.dumps(credentials, separators=(",", ":")))
+        return quote(json.dumps(credentials, separators=(",", ":")), safe="")
 
     def test_requires_username_in_uri(self) -> None:
         with self.assertRaises(InvalidStorageUri):
@@ -97,15 +97,15 @@ class TestS3Storage(StorageTestCase, TestCase):
             region_name="US_EAST")
 
     def test_accepts_json_encoded_credentials_in_username(self) -> None:
-        credentials = self.create_json_credentials("ACCESS-KEY", "ACCESS-SECRET")
+        credentials = self.create_json_credentials("ACCESS/KEY", "ACCESS/SECRET")
 
         storage = get_storage(f"s3://{credentials}@bucket/some/file")
 
         cast(S3Storage, storage)._connect()
 
         self.mock_session_class.assert_called_with(
-            aws_access_key_id="ACCESS-KEY",
-            aws_secret_access_key="ACCESS-SECRET",
+            aws_access_key_id="ACCESS/KEY",
+            aws_secret_access_key="ACCESS/SECRET",
             aws_session_token=None,
             region_name=None)
 

--- a/tests/test_s3_storage.py
+++ b/tests/test_s3_storage.py
@@ -3,7 +3,7 @@ import os
 from unittest import mock, TestCase
 from urllib.parse import quote
 
-from typing import cast, Dict, List, Optional
+from typing import cast, Optional
 from botocore.exceptions import ClientError
 
 from storage.storage import get_storage, InvalidStorageUri, NotFoundError
@@ -32,7 +32,7 @@ class TestS3Storage(StorageTestCase, TestCase):
             cleanup_nested_directory(self.temp_directory)
 
     def _generate_storage_uri(
-            self, object_path: str, parameters: Optional[Dict[str, str]] = None) -> str:
+            self, object_path: str, parameters: Optional[dict[str, str]] = None) -> str:
         return "s3://access_key:access_secret@bucket/some/file"
 
     def create_json_credentials(
@@ -444,7 +444,7 @@ class TestS3Storage(StorageTestCase, TestCase):
         }
 
         mock_path_exists.return_value = False
-        path_mock_path_exists_calls: List[str] = []
+        path_mock_path_exists_calls: list[str] = []
 
         def mock_path_exists_side_effect(path: str) -> bool:
             if any(path in x for x in path_mock_path_exists_calls):
@@ -518,7 +518,7 @@ class TestS3Storage(StorageTestCase, TestCase):
         }
 
         mock_path_exists.return_value = False
-        path_mock_path_exists_calls: List[str] = []
+        path_mock_path_exists_calls: list[str] = []
 
         def mock_path_exists_side_effect(path: str) -> bool:
             if any(path in x for x in path_mock_path_exists_calls):
@@ -606,7 +606,7 @@ class TestS3Storage(StorageTestCase, TestCase):
         }
 
         mock_path_exists.return_value = False
-        path_mock_path_exists_calls: List[str] = []
+        path_mock_path_exists_calls: list[str] = []
 
         def mock_path_exists_side_effect(path: str) -> bool:
             if any(path in x for x in path_mock_path_exists_calls):
@@ -728,7 +728,7 @@ class TestS3Storage(StorageTestCase, TestCase):
         }
 
         mock_path_exists.return_value = False
-        path_mock_path_exists_calls: List[str] = []
+        path_mock_path_exists_calls: list[str] = []
 
         def mock_path_exists_side_effect(path: str) -> bool:
             if any(path in x for x in path_mock_path_exists_calls):
@@ -827,7 +827,7 @@ class TestS3Storage(StorageTestCase, TestCase):
         }
 
         mock_path_exists.return_value = False
-        path_mock_path_exists_calls: List[str] = []
+        path_mock_path_exists_calls: list[str] = []
 
         def mock_path_exists_side_effect(path: str) -> bool:
             if any(path in x for x in path_mock_path_exists_calls):


### PR DESCRIPTION
This PR adds support for accessing S3 buckets owned by third parties. It also adds a new way to specify credentials in S3 storage URIs, by putting JSON in the URI's username field and omitting a password. The JSON structure includes support for specifying a role that is to be assumed in order to access the bucket.

I have added a new integration test that exercises the new S3 storage URI with JSON credentials feature.

@ustudio/reviewers Please review