### PR TITLE
Fix Package Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 storage
 =======
 
-[![build status](https://circleci.com/gh/ustudio/storage.png?circle-token=3b3e87d02777a6e2ef90bcb9651457a215b6d333)](https://circleci.com/gh/ustudio/storage)
+[![build status](https://dl.circleci.com/status-badge/img/gh/ustudio/storage/tree/master.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/ustudio/storage/tree/master)
 
 Python library for accessing files over various file transfer protocols.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Python library for accessing files over various file transfer protocols.
 Install via pip:
 
 ```sh
-pip install object_storage
+pip install object-storage
 ```
 
 ## Quick Start ##

--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ Install via pip:
 pip install object_storage
 ```
 
-The current version is `0.14.4`.
-For Python 2.7, use the latest release from the `v0.12` branch.
-
 ## Quick Start ##
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "object-storage"
 version = "0.15.0"
 description = "Python library for accessing files over various file transfer protocols."
 authors = ["uStudio Developers <dev@ustudio.com>"]
-license = "Apache 2.0"
+license = "Apache-2.0"
 readme = "README.md"
 packages = [{include = "storage"}]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "object-storage"
-version = "0.15.0"
+version = "0.15.1"
 description = "Python library for accessing files over various file transfer protocols."
 authors = ["uStudio Developers <dev@ustudio.com>"]
 repository = "https://github.com/ustudio/storage"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "object-storage"
 version = "0.15.0"
 description = "Python library for accessing files over various file transfer protocols."
 authors = ["uStudio Developers <dev@ustudio.com>"]
+repository = "https://github.com/ustudio/storage"
 license = "Apache-2.0"
 readme = "README.md"
 packages = [{include = "storage"}]


### PR DESCRIPTION
This PR fixes a couple minor issues I discovered after publishing v0.15.0 to PyPI. In particular, PyPI wasn't recognizing the license correctly and it no longer linked back to the GitHub page.

In addition, I fixed some minor annoyances in the README. The build status badge was showing a broken image, so I updated it. The example `pip install` command was using the non-canonical package name containing an underscore, which I replaced with a dash. Finally, the README listed the wrong "current version" and indicated how to get legacy Python support, which I have removed.

@ustudio/reviewers Please review