### PR TITLE
Force V4 Signatures for S3 Download URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "object-storage"
-version = "0.15.1"
+version = "0.15.2"
 description = "Python library for accessing files over various file transfer protocols."
 authors = ["uStudio Developers <dev@ustudio.com>"]
 repository = "https://github.com/ustudio/storage"

--- a/storage/s3_storage.py
+++ b/storage/s3_storage.py
@@ -5,6 +5,7 @@ from urllib.parse import parse_qs, unquote
 
 import boto3.session
 import boto3.s3.transfer
+import botocore.config
 from botocore.exceptions import ClientError
 from botocore.session import Session
 
@@ -80,7 +81,7 @@ class S3Storage(Storage):
             aws_session_token=session_token,
             region_name=self._region)
 
-        return aws_session.client("s3")
+        return aws_session.client("s3", config=botocore.config.Config(signature_version="v4"))
 
     def save_to_filename(self, file_path: str) -> None:
         client = self._connect()

--- a/stubs/boto3/session.pyi
+++ b/stubs/boto3/session.pyi
@@ -1,4 +1,4 @@
-import botocore.client
+import botocore.config
 import botocore.session
 
 from typing import Optional, Union
@@ -26,5 +26,5 @@ class Session(object):
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         aws_session_token: Optional[str] = None,
-        config: Optional[botocore.client.Config] = None
+        config: Optional[botocore.config.Config] = None
         ) -> botocore.session.Session: ...

--- a/stubs/botocore/client.pyi
+++ b/stubs/botocore/client.pyi
@@ -1,2 +1,0 @@
-class Config(object):
-    pass

--- a/stubs/botocore/config.pyi
+++ b/stubs/botocore/config.pyi
@@ -1,0 +1,31 @@
+from typing import Optional, Union
+
+
+class Config():
+    def __init__(
+        self,
+        region_name: Optional[str] = None,
+        signature_version: Optional[str] = None,
+        user_agent: Optional[str] = None,
+        user_agent_extra: Optional[str] = None,
+        user_agent_appid: Optional[str] = None,
+        connect_timeout: Optional[Union[float, int]] = None,
+        read_timeout: Optional[Union[float, int]] = None,
+        parameter_validation: Optional[bool] = None,
+        max_pool_connections: Optional[int] = None,
+        proxies: Optional[dict[str, object]] = None,
+        proxies_config: Optional[dict[str, object]] = None,
+        s3: Optional[dict[str, object]] = None,
+        retries: Optional[dict[str, object]] = None,
+        client_cert: Optional[Union[str, tuple[str, str]]] = None,
+        inject_host_prefix: Optional[bool] = None,
+        use_dualstack_endpoint: Optional[bool] = None,
+        use_fips_endpoint: Optional[bool] = None,
+        ignore_configured_endpoint_urls: Optional[bool] = None,
+        tcp_keepalive: Optional[bool] = None,
+        request_min_compression_size_bytes: Optional[int] = None,
+        disable_request_compression: Optional[bool] = None,
+        sigv4a_signing_region_set: Optional[str] = None,
+        client_context_params: Optional[dict[str, object]] = None
+    ) -> None:
+        ...

--- a/tests/test_s3_storage.py
+++ b/tests/test_s3_storage.py
@@ -21,6 +21,11 @@ class TestS3Storage(StorageTestCase, TestCase):
         super().setUp()
         self.temp_directory = None
 
+        config_class_patcher = mock.patch("botocore.config.Config", autospec=True)
+        self.mock_config_class = config_class_patcher.start()
+        self.addCleanup(config_class_patcher.stop)
+        self.mock_config = self.mock_config_class.return_value
+
         session_class_patcher = mock.patch("boto3.session.Session", autospec=True)
         self.mock_session_class = session_class_patcher.start()
         self.addCleanup(session_class_patcher.stop)
@@ -237,7 +242,8 @@ class TestS3Storage(StorageTestCase, TestCase):
             aws_session_token=None,
             region_name="US_EAST")
 
-        self.mock_session.client.assert_called_with("s3")
+        self.mock_config_class.assert_called_with(signature_version="v4")
+        self.mock_session.client.assert_called_with("s3", config=self.mock_config)
 
         mock_s3.put_object.assert_called_with(Bucket="bucket", Key="some/file", Body=mock_file)
 
@@ -270,7 +276,8 @@ class TestS3Storage(StorageTestCase, TestCase):
             aws_session_token=None,
             region_name="US_EAST")
 
-        self.mock_session.client.assert_called_with("s3")
+        self.mock_config_class.assert_called_with(signature_version="v4")
+        self.mock_session.client.assert_called_with("s3", config=self.mock_config)
 
         mock_transfer_class.assert_called_with(mock_s3)
 
@@ -312,7 +319,8 @@ class TestS3Storage(StorageTestCase, TestCase):
             aws_session_token=None,
             region_name="US_EAST")
 
-        self.mock_session.client.assert_called_with("s3")
+        self.mock_config_class.assert_called_with(signature_version="v4")
+        self.mock_session.client.assert_called_with("s3", config=self.mock_config)
         mock_s3.get_object.assert_called_with(Bucket="bucket", Key="some/file")
         mock_file.write.assert_has_calls([
             mock.call(b"some"),
@@ -331,7 +339,8 @@ class TestS3Storage(StorageTestCase, TestCase):
         with self.assertRaises(NotFoundError):
             storage.save_to_file(mock_file)
 
-        self.mock_session.client.assert_called_with("s3")
+        self.mock_config_class.assert_called_with(signature_version="v4")
+        self.mock_session.client.assert_called_with("s3", config=self.mock_config)
         mock_s3.get_object.assert_called_with(Bucket="bucket", Key="some/file")
         mock_file.write.assert_not_called()
 
@@ -352,7 +361,8 @@ class TestS3Storage(StorageTestCase, TestCase):
             aws_session_token=None,
             region_name="US_EAST")
 
-        self.mock_session.client.assert_called_with("s3")
+        self.mock_config_class.assert_called_with(signature_version="v4")
+        self.mock_session.client.assert_called_with("s3", config=self.mock_config)
 
         mock_transfer_class.assert_called_with(mock_s3)
         mock_transfer.download_file.assert_called_with("bucket", "some/file", "destination/file")
@@ -469,7 +479,8 @@ class TestS3Storage(StorageTestCase, TestCase):
         mock_s3_client.list_objects.assert_called_with(Bucket="bucket", Prefix="directory/")
         mock_makedirs.assert_has_calls(
             [mock.call("save_to_directory/b"), mock.call("save_to_directory/e/f")])
-        self.mock_session.client.assert_called_with("s3")
+        self.mock_config_class.assert_called_with(signature_version="v4")
+        self.mock_session.client.assert_called_with("s3", config=self.mock_config)
 
         mock_s3_client.download_file.assert_has_calls([
             mock.call("bucket", "directory/b/c.txt", "save_to_directory/b/c.txt"),
@@ -551,7 +562,8 @@ class TestS3Storage(StorageTestCase, TestCase):
         mock_s3_client.list_objects.assert_called_with(Bucket="bucket", Prefix="directory/")
         mock_makedirs.assert_has_calls(
             [mock.call("save_to_directory/b"), mock.call("save_to_directory/e/f")])
-        self.mock_session.client.assert_called_with("s3")
+        self.mock_config_class.assert_called_with(signature_version="v4")
+        self.mock_session.client.assert_called_with("s3", config=self.mock_config)
 
         self.assertEqual(5, mock_s3_client.download_file.call_count)
         mock_s3_client.download_file.assert_has_calls([
@@ -639,7 +651,8 @@ class TestS3Storage(StorageTestCase, TestCase):
 
         mock_s3_client.list_objects.assert_called_with(Bucket="bucket", Prefix="directory/")
         mock_makedirs.assert_called_once_with("save_to_directory/b")
-        self.mock_session.client.assert_called_with("s3")
+        self.mock_config_class.assert_called_with(signature_version="v4")
+        self.mock_session.client.assert_called_with("s3", config=self.mock_config)
 
         self.assertEqual(5, mock_s3_client.download_file.call_count)
         mock_s3_client.download_file.assert_has_calls([
@@ -683,7 +696,8 @@ class TestS3Storage(StorageTestCase, TestCase):
             aws_session_token=None,
             region_name="US_EAST")
 
-        self.mock_session.client.assert_called_with("s3")
+        self.mock_config_class.assert_called_with(signature_version="v4")
+        self.mock_session.client.assert_called_with("s3", config=self.mock_config)
 
         mock_s3_client.list_objects.assert_called_with(Bucket="bucket", Prefix="directory/")
 
@@ -1019,7 +1033,8 @@ class TestS3Storage(StorageTestCase, TestCase):
             aws_session_token=None,
             region_name="US_EAST")
 
-        self.mock_session.client.assert_called_with("s3")
+        self.mock_config_class.assert_called_with(signature_version="v4")
+        self.mock_session.client.assert_called_with("s3", config=self.mock_config)
 
         mock_s3.delete_object.assert_called_with(Bucket="bucket", Key="some/file")
 
@@ -1095,7 +1110,8 @@ class TestS3Storage(StorageTestCase, TestCase):
             aws_session_token=None,
             region_name=None)
 
-        self.mock_session.client.assert_called_with("s3")
+        self.mock_config_class.assert_called_with(signature_version="v4")
+        self.mock_session.client.assert_called_with("s3", config=self.mock_config)
 
         mock_s3.list_objects.assert_called_once_with(Bucket="bucket", Prefix="some/dir/")
         mock_s3.delete_objects.assert_called_once_with(
@@ -1139,7 +1155,8 @@ class TestS3Storage(StorageTestCase, TestCase):
             aws_session_token=None,
             region_name=None)
 
-        self.mock_session.client.assert_called_with("s3")
+        self.mock_config_class.assert_called_with(signature_version="v4")
+        self.mock_session.client.assert_called_with("s3", config=self.mock_config)
 
         mock_s3.list_objects.assert_called_once_with(Bucket="bucket", Prefix="some/dir/")
         mock_s3.delete_objects.assert_not_called()
@@ -1177,7 +1194,8 @@ class TestS3Storage(StorageTestCase, TestCase):
             aws_session_token=None,
             region_name=None)
 
-        self.mock_session.client.assert_called_with("s3")
+        self.mock_config_class.assert_called_with(signature_version="v4")
+        self.mock_session.client.assert_called_with("s3", config=self.mock_config)
 
         mock_s3.list_objects.assert_called_once_with(Bucket="bucket", Prefix="some/dir/")
         mock_s3.delete_objects.assert_called_once()
@@ -1215,7 +1233,8 @@ class TestS3Storage(StorageTestCase, TestCase):
             aws_session_token=None,
             region_name=None)
 
-        self.mock_session.client.assert_called_with("s3")
+        self.mock_config_class.assert_called_with(signature_version="v4")
+        self.mock_session.client.assert_called_with("s3", config=self.mock_config)
 
         mock_s3.list_objects.assert_called_once_with(Bucket="bucket", Prefix="some/dir/")
         mock_s3.delete_objects.assert_called_once()


### PR DESCRIPTION
This PR updates the `s3` storage protocol to enforce "v4" signatures when generating signed URLs via `get_download_url`. It appears that there are certain instances where `boto3` opts to use v2 signatures, but AWS requires v4 signatures, possibly related to having `us-east-1` as the default region for the authenticating user, but then accessing a bucket in another region which doesn't support v2 signatures.

I also added integration tests for generating download URLs, although the default configuration in CI wasn't initially failing. I only enabled the tests for AWS S3 (with and without JSON credentials) and Google Storage, as the other configurations aren't set up for download URLs.

The type annotations for the `Config` object in `botocore` were a little ambiguous. The documentation for `Session.client` says the class is at `botocore.client.Config`, but the link is to `botocore.config.Config`. I tried making one a type alias for the other, but that caused an internal exception inside MyPy. Instead, I moved the class to `botocore.config.Config`, and defined the `__init__` based on the documentation for that class.

@ustudio/reviewers Please review