### PR TITLE
Correctly handle paginated responses from s3 when operating on directories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "object-storage"
-version = "0.15.2"
+version = "0.15.3"
 description = "Python library for accessing files over various file transfer protocols."
 authors = ["uStudio Developers <dev@ustudio.com>"]
 repository = "https://github.com/ustudio/storage"

--- a/storage/s3_storage.py
+++ b/storage/s3_storage.py
@@ -111,8 +111,7 @@ class S3Storage(Storage):
     def save_to_directory(self, directory_path: str) -> None:
         client = self._connect()
         directory_prefix = "{}/".format(self._keyname)
-        dir_object = client.list_objects(
-            Bucket=self._bucket, Prefix=directory_prefix, Delimiter="/")
+        dir_object = client.list_objects(Bucket=self._bucket, Prefix=directory_prefix)
 
         if "Contents" not in dir_object:
             raise NotFoundError("No Files Found")
@@ -123,8 +122,7 @@ class S3Storage(Storage):
             dir_object = client.list_objects(
                 Bucket=self._bucket,
                 Prefix=directory_prefix,
-                Delimiter="/",
-                Marker=dir_object["NextMarker"])
+                Marker=dir_object["Contents"][-1]["Key"])
 
             dir_contents += dir_object["Contents"]
 
@@ -194,10 +192,7 @@ class S3Storage(Storage):
         client = self._connect()
         directory_prefix = "{}/".format(self._keyname)
 
-        dir_object = client.list_objects(
-            Bucket=self._bucket,
-            Prefix=directory_prefix,
-            Delimiter="/")
+        dir_object = client.list_objects(Bucket=self._bucket, Prefix=directory_prefix)
 
         if "Contents" not in dir_object:
             raise NotFoundError("No Files Found")
@@ -208,8 +203,7 @@ class S3Storage(Storage):
             dir_object = client.list_objects(
                 Bucket=self._bucket,
                 Prefix=directory_prefix,
-                Delimiter="/",
-                Marker=dir_object["NextMarker"])
+                Marker=dir_object["Contents"][-1]["Key"])
 
             object_keys.append([{"Key": o.get("Key", None)} for o in dir_object["Contents"]])
 

--- a/stubs/botocore/session.pyi
+++ b/stubs/botocore/session.pyi
@@ -20,7 +20,11 @@ ListObjectResponse = TypedDict(
     })
 
 ListResponse = TypedDict(
-    "ListResponse", {"Contents": List[ListObjectResponse]})
+    "ListResponse", {
+        "Contents": List[ListObjectResponse],
+        "IsTruncated": bool,
+        "NextMarker": Optional[str]
+    })
 
 DeleteEntries = TypedDict(
     "DeleteEntries", {"Objects": List[Dict[str, Optional[str]]]})
@@ -32,7 +36,14 @@ class Session(object):
 
     def get_object(self, Bucket: str, Key: str) -> ObjectResponse: ...
 
-    def list_objects(self, Bucket: str, Prefix: str) -> ListResponse: ...
+    def list_objects(
+        self,
+        Bucket: str,
+        Prefix: str,
+        Delimiter: Optional[str] = None,
+        Marker: Optional[str] = None
+    ) -> ListResponse:
+        ...
 
     def download_file(self, Bucket: str, Key: str, filepath: str) -> None: ...
 

--- a/stubs/botocore/session.pyi
+++ b/stubs/botocore/session.pyi
@@ -40,7 +40,6 @@ class Session(object):
         self,
         Bucket: str,
         Prefix: str,
-        Delimiter: Optional[str] = None,
         Marker: Optional[str] = None
     ) -> ListResponse:
         ...

--- a/tests/test_s3_storage.py
+++ b/tests/test_s3_storage.py
@@ -477,8 +477,7 @@ class TestS3Storage(StorageTestCase, TestCase):
             aws_session_token=None,
             region_name="US_EAST")
 
-        mock_s3_client.list_objects.assert_called_with(
-            Bucket="bucket", Prefix="directory/", Delimiter="/")
+        mock_s3_client.list_objects.assert_called_with(Bucket="bucket", Prefix="directory/")
         mock_makedirs.assert_has_calls(
             [mock.call("save_to_directory/b"), mock.call("save_to_directory/e/f")])
         self.mock_config_class.assert_called_with(signature_version="v4")
@@ -516,8 +515,7 @@ class TestS3Storage(StorageTestCase, TestCase):
                         "Key": "directory/3"
                     }
                 ],
-                "IsTruncated": True,
-                "NextMarker": "Page2Marker"
+                "IsTruncated": True
             },
             {
                 "Contents": [
@@ -528,8 +526,7 @@ class TestS3Storage(StorageTestCase, TestCase):
                         "Key": "directory/5"
                     }
                 ],
-                "IsTruncated": True,
-                "NextMarker": "Page3Marker"
+                "IsTruncated": True
             },
             {
                 "Contents": [
@@ -568,9 +565,9 @@ class TestS3Storage(StorageTestCase, TestCase):
             region_name="US_EAST")
 
         mock_s3_client.list_objects.assert_has_calls([
-            mock.call(Bucket="bucket", Prefix="directory/", Delimiter="/"),
-            mock.call(Bucket="bucket", Prefix="directory/", Delimiter="/", Marker="Page2Marker"),
-            mock.call(Bucket="bucket", Prefix="directory/", Delimiter="/", Marker="Page3Marker")])
+            mock.call(Bucket="bucket", Prefix="directory/"),
+            mock.call(Bucket="bucket", Prefix="directory/", Marker="directory/3"),
+            mock.call(Bucket="bucket", Prefix="directory/", Marker="directory/5")])
 
         self.mock_config_class.assert_called_with(signature_version="v4")
         self.mock_session.client.assert_called_with("s3", config=self.mock_config)
@@ -656,8 +653,7 @@ class TestS3Storage(StorageTestCase, TestCase):
             aws_session_token=None,
             region_name="US_EAST")
 
-        mock_s3_client.list_objects.assert_called_with(
-            Bucket="bucket", Prefix="directory/", Delimiter="/")
+        mock_s3_client.list_objects.assert_called_with(Bucket="bucket", Prefix="directory/")
         mock_makedirs.assert_has_calls(
             [mock.call("save_to_directory/b"), mock.call("save_to_directory/e/f")])
         self.mock_config_class.assert_called_with(signature_version="v4")
@@ -748,8 +744,7 @@ class TestS3Storage(StorageTestCase, TestCase):
             aws_session_token=None,
             region_name="US_EAST")
 
-        mock_s3_client.list_objects.assert_called_with(
-            Bucket="bucket", Prefix="directory/", Delimiter="/")
+        mock_s3_client.list_objects.assert_called_with(Bucket="bucket", Prefix="directory/")
         mock_makedirs.assert_called_once_with("save_to_directory/b")
         self.mock_config_class.assert_called_with(signature_version="v4")
         self.mock_session.client.assert_called_with("s3", config=self.mock_config)
@@ -799,8 +794,7 @@ class TestS3Storage(StorageTestCase, TestCase):
         self.mock_config_class.assert_called_with(signature_version="v4")
         self.mock_session.client.assert_called_with("s3", config=self.mock_config)
 
-        mock_s3_client.list_objects.assert_called_with(
-            Bucket="bucket", Prefix="directory/", Delimiter="/")
+        mock_s3_client.list_objects.assert_called_with(Bucket="bucket", Prefix="directory/")
 
     @mock.patch("storage.retry.time.sleep", autospec=True)
     @mock.patch("storage.retry.random.uniform", autospec=True)
@@ -1217,8 +1211,7 @@ class TestS3Storage(StorageTestCase, TestCase):
         self.mock_config_class.assert_called_with(signature_version="v4")
         self.mock_session.client.assert_called_with("s3", config=self.mock_config)
 
-        mock_s3.list_objects.assert_called_once_with(
-            Bucket="bucket", Prefix="some/dir/", Delimiter="/")
+        mock_s3.list_objects.assert_called_once_with(Bucket="bucket", Prefix="some/dir/")
         mock_s3.delete_objects.assert_called_once_with(
             Bucket="bucket",
             Delete={
@@ -1279,8 +1272,7 @@ class TestS3Storage(StorageTestCase, TestCase):
                         "StorageClass": "STANDARD"
                     }
                 ],
-                "IsTruncated": True,
-                "NextMarker": "Page2Marker"
+                "IsTruncated": True
             },
             {
                 "Contents": [
@@ -1299,8 +1291,7 @@ class TestS3Storage(StorageTestCase, TestCase):
                         "StorageClass": "STANDARD"
                     }
                 ],
-                "IsTruncated": True,
-                "NextMarker": "Page3Marker"
+                "IsTruncated": True
             },
             {
                 "Contents": [
@@ -1337,9 +1328,9 @@ class TestS3Storage(StorageTestCase, TestCase):
         self.mock_session.client.assert_called_with("s3", config=self.mock_config)
 
         mock_s3.list_objects.assert_has_calls([
-            mock.call(Bucket="bucket", Prefix="some/dir/", Delimiter="/"),
-            mock.call(Bucket="bucket", Prefix="some/dir/", Delimiter="/", Marker="Page2Marker"),
-            mock.call(Bucket="bucket", Prefix="some/dir/", Delimiter="/", Marker="Page3Marker")])
+            mock.call(Bucket="bucket", Prefix="some/dir/"),
+            mock.call(Bucket="bucket", Prefix="some/dir/", Marker="directory/3"),
+            mock.call(Bucket="bucket", Prefix="some/dir/", Marker="directory/5")])
         mock_s3.delete_objects.assert_has_calls([
             mock.call(
                 Bucket="bucket",
@@ -1404,8 +1395,7 @@ class TestS3Storage(StorageTestCase, TestCase):
         self.mock_config_class.assert_called_with(signature_version="v4")
         self.mock_session.client.assert_called_with("s3", config=self.mock_config)
 
-        mock_s3.list_objects.assert_called_once_with(
-            Bucket="bucket", Prefix="some/dir/", Delimiter="/")
+        mock_s3.list_objects.assert_called_once_with(Bucket="bucket", Prefix="some/dir/")
         mock_s3.delete_objects.assert_not_called()
 
     def test_delete_directory_raises_not_found_error_when_files_do_not_exist(self) -> None:
@@ -1445,8 +1435,7 @@ class TestS3Storage(StorageTestCase, TestCase):
         self.mock_config_class.assert_called_with(signature_version="v4")
         self.mock_session.client.assert_called_with("s3", config=self.mock_config)
 
-        mock_s3.list_objects.assert_called_once_with(
-            Bucket="bucket", Prefix="some/dir/", Delimiter="/")
+        mock_s3.list_objects.assert_called_once_with(Bucket="bucket", Prefix="some/dir/")
         mock_s3.delete_objects.assert_called_once()
 
     def test_delete_directory_raises_original_exception_when_not_404(self) -> None:
@@ -1486,8 +1475,7 @@ class TestS3Storage(StorageTestCase, TestCase):
         self.mock_config_class.assert_called_with(signature_version="v4")
         self.mock_session.client.assert_called_with("s3", config=self.mock_config)
 
-        mock_s3.list_objects.assert_called_once_with(
-            Bucket="bucket", Prefix="some/dir/", Delimiter="/")
+        mock_s3.list_objects.assert_called_once_with(Bucket="bucket", Prefix="some/dir/")
         mock_s3.delete_objects.assert_called_once()
 
     def test_get_download_url_calls_boto_generate_presigned_url_with_correct_data(self) -> None:


### PR DESCRIPTION
This PR updates the `save_to_directory` and `delete_directory` methods of the S3 storage object to correctly iterate over all the pages returned by `list_objects`, when an S3 directory contains more than 1000 objects.

In looking up the documentation, I noticed that there is a `list_objects_v2`, which is now recommended; however, the semantics are slightly different, depending on bucket configurations, so I opted not to switch to that. I attempted to use the `NextMarker` return value from the response to iterate over the pages. However, the documentation states that we have to pass a `Delimiter` and, when doing so, the listing is no longer recursive of the whole "directory." Instead, I iterate by using the last item in the `Contents`, which is documented to iterate over pages correctly.

When deleting objects, the `delete_objects` method is limited to a maximum of 1000 objects per-call, so we also have to paginate the call to that method. However, in order to avoid any potential problems with trying to paginate over a list of objects while they are being deleted, I opted to build up the list of all the pages of objects, then delete them one page at a time. Obviously, there might be memory issues with extremely large directories, but this seemed like the less error prone method.

@ustudio/reviewers Please review